### PR TITLE
[week2] B16948_데스나이트, B17298_오큰수, B17626_FourSquares

### DIFF
--- a/길민지/Week_2/B16948_데스나이트.java
+++ b/길민지/Week_2/B16948_데스나이트.java
@@ -5,67 +5,67 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.StringTokenizer;
 
-public class B16948_µ¥½º³ªÀÌÆ®{
+public class B16948_ë°ìŠ¤ë‚˜ì´íŠ¸Æ®{
 	static int N;
 	static int r1, c1, r2, c2;
 	static int dr[] = {-2, -2, 0, 0, 2, 2};
 	static int dc[] = {-1, 1, -2, 2, -1, 1};
 	static boolean [][] selected;
-	
-	// ¹üÀ§ Ã¼Å©
+
+	// ë²”ìœ„ ì²´í¬
 	public static boolean validChk(int r, int c) {
 		if (r<0 || c<0 || r>N-1 || c>N-1) return false;
 		return true;
 	}
-	
+
 	public static int BFS() {
 		Queue <Integer[]> que = new ArrayDeque<>();
-		que.add(new Integer[] {r1, c1, 0}); // ½ÃÀÛÁ¡ Ãß°¡
+		que.add(new Integer[] {r1, c1, 0}); // ì‹œì‘ì  ì¶”ê°€
 		selected[r1][c1] = true;
-		
+
 		while(!que.isEmpty()) {
 			int now_r = que.peek()[0];
 			int now_c = que.peek()[1];
 			int now_d = que.poll()[2];
-			
-			// 6¹æ Å½»ö
+
+			// 6ë°© íƒìƒ‰
 			for(int i=0; i<6; i++) {
 				int next_r = now_r + dr[i];
 				int next_c = now_c + dc[i];
 				int next_d = now_d + 1;
-				
-				if(next_r == r2 && next_c == c2) { // ÀÌµ¿ ¿Ï·á
+
+				if(next_r == r2 && next_c == c2) { // ì´ë™ ì™„ë£Œ
 					return next_d;
 				}
-				
-				// À¯È¿¼º Ã¼Å©
+
+				// ìœ íš¨ì„± ì²´í¬
 				if(!validChk(next_r, next_c)||selected[next_r][next_c]) continue;
-				que.add(new Integer[] {next_r, next_c, next_d}); // ´ÙÀ½ À§Ä¡ Ãß°¡
+				que.add(new Integer[] {next_r, next_c, next_d}); // ë‹¤ìŒ ìœ„ì¹˜ ì¶”ê°€
 				selected[next_r][next_c] = true;
 			}
 		}
-		
+
 		return -1;
 	}
-	
+
 	public static void main(String [] args) throws IOException {
 		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
 		StringTokenizer st = new StringTokenizer(bf.readLine());
-		
-		// ÀÔ·Â
+
+		// ì…ë ¥
 		N = Integer.parseInt(st.nextToken());
-		
+
 		st = new StringTokenizer(bf.readLine());
 		r1 = Integer.parseInt(st.nextToken());
 		c1 = Integer.parseInt(st.nextToken());
 		r2 = Integer.parseInt(st.nextToken());
 		c2 = Integer.parseInt(st.nextToken());
-		
-		// ¹è¿­ ÃÊ±âÈ­
+
+		// ë°°ì—´ ì´ˆê¸°í™”
 		selected = new boolean[N][N];
-		
-		// Á¤´ä Ãâ·Â
+
+		// ì •ë‹µ ì¶œë ¥
 		System.out.println(BFS());
 	}
-	
+
 }

--- a/길민지/Week_2/B16948_데스나이트.java
+++ b/길민지/Week_2/B16948_데스나이트.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B16948_데스나이트{
+	static int N;
+	static int r1, c1, r2, c2;
+	static int dr[] = {-2, -2, 0, 0, 2, 2};
+	static int dc[] = {-1, 1, -2, 2, -1, 1};
+	static boolean [][] selected;
+	
+	// 범위 체크
+	public static boolean validChk(int r, int c) {
+		if (r<0 || c<0 || r>N-1 || c>N-1) return false;
+		return true;
+	}
+	
+	public static int BFS() {
+		Queue <Integer[]> que = new ArrayDeque<>();
+		que.add(new Integer[] {r1, c1, 0}); // 시작점 추가
+		selected[r1][c1] = true;
+		
+		while(!que.isEmpty()) {
+			int now_r = que.peek()[0];
+			int now_c = que.peek()[1];
+			int now_d = que.poll()[2];
+			
+			// 6방 탐색
+			for(int i=0; i<6; i++) {
+				int next_r = now_r + dr[i];
+				int next_c = now_c + dc[i];
+				int next_d = now_d + 1;
+				
+				if(next_r == r2 && next_c == c2) { // 이동 완료
+					return next_d;
+				}
+				
+				// 유효성 체크
+				if(!validChk(next_r, next_c)||selected[next_r][next_c]) continue;
+				que.add(new Integer[] {next_r, next_c, next_d}); // 다음 위치 추가
+				selected[next_r][next_c] = true;
+			}
+		}
+		
+		return -1;
+	}
+	
+	public static void main(String [] args) throws IOException {
+		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(bf.readLine());
+		
+		// 입력
+		N = Integer.parseInt(st.nextToken());
+		
+		st = new StringTokenizer(bf.readLine());
+		r1 = Integer.parseInt(st.nextToken());
+		c1 = Integer.parseInt(st.nextToken());
+		r2 = Integer.parseInt(st.nextToken());
+		c2 = Integer.parseInt(st.nextToken());
+		
+		// 배열 초기화
+		selected = new boolean[N][N];
+		
+		// 정답 출력
+		System.out.println(BFS());
+	}
+	
+}

--- a/길민지/Week_2/B17298_오큰수.java
+++ b/길민지/Week_2/B17298_오큰수.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Stack;
 import java.util.StringTokenizer;
 
-public class B17298_¿ÀÅ«¼ö {
+public class B17298_ì˜¤í°ìˆ˜ {
 	static int N;
 	static int result[];
 	static Stack<Integer[]> stack;
@@ -14,27 +14,27 @@ public class B17298_¿ÀÅ«¼ö {
 		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
 		StringTokenizer st = new StringTokenizer(bf.readLine());
 		
-		// Ã¹Â°ÁÙ ÀÔ·Â
+		// ì²«ì§¸ì¤„ ì…ë ¥
 		N = Integer.parseInt(st.nextToken());
 		
-		// ÃÊ±âÈ­
+		// ì´ˆê¸°í™”
 		result = new int[N];
 		stack = new Stack<Integer[]>();
 		
-		// ¼ö¿­ ÀÔ·Â
+		// ìˆ˜ì—´ ì…ë ¥
 		st = new StringTokenizer(bf.readLine());
 		for (int i=0; i<N; i++) {
 			int num = Integer.parseInt(st.nextToken());
 			result[i] = -1;
 			
 			while(!stack.isEmpty() && stack.peek()[1]<num) { 
-				// ½ºÅÃ¿¡ ÇöÀç °ªº¸´Ù ÀÛÀº °ªÀÌ ÀÖ´Ù¸é ±× ÀÚ¸®¿¡ ÇöÀç °ª ÀúÀå
+				// ìŠ¤íƒì— í˜„ì¬ ê°’ë³´ë‹¤ ì‘ì€ ê°’ì´ ìˆë‹¤ë©´ ê·¸ ìë¦¬ì— í˜„ì¬ ê°’ ì €ì¥
 				result[stack.pop()[0]] = num;
 			}
-			stack.add(new Integer[] {i, num}); // ÇöÀç ÀÎµ¦½º, °ª push
+			stack.add(new Integer[] {i, num}); // í˜„ì¬ ì¸ë±ìŠ¤, ê°’ push
 		}
 		
-		// Ãâ·Â
+		// ì¶œë ¥
 		StringBuilder sb = new StringBuilder();
 		for(int i : result) sb.append(i).append(" ");
 		System.out.println(sb);

--- a/길민지/Week_2/B17298_오큰수.java
+++ b/길민지/Week_2/B17298_오큰수.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class B17298_오큰수 {
+	static int N;
+	static int result[];
+	static Stack<Integer[]> stack;
+	
+	public static void main(String [] args) throws IOException {
+		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(bf.readLine());
+		
+		// 첫째줄 입력
+		N = Integer.parseInt(st.nextToken());
+		
+		// 초기화
+		result = new int[N];
+		stack = new Stack<Integer[]>();
+		
+		// 수열 입력
+		st = new StringTokenizer(bf.readLine());
+		for (int i=0; i<N; i++) {
+			int num = Integer.parseInt(st.nextToken());
+			result[i] = -1;
+			
+			while(!stack.isEmpty() && stack.peek()[1]<num) { 
+				// 스택에 현재 값보다 작은 값이 있다면 그 자리에 현재 값 저장
+				result[stack.pop()[0]] = num;
+			}
+			stack.add(new Integer[] {i, num}); // 현재 인덱스, 값 push
+		}
+		
+		// 출력
+		StringBuilder sb = new StringBuilder();
+		for(int i : result) sb.append(i).append(" ");
+		System.out.println(sb);
+	}
+}

--- a/길민지/Week_2/B17626_FourSquares.java
+++ b/길민지/Week_2/B17626_FourSquares.java
@@ -1,0 +1,39 @@
+package algo0501;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class B17626_FourSquares {
+	static int N;
+	static int dp[];
+	
+	public static void DP(int num) {
+		for (int i=2; i<=num; i++){ // dp[2] ~ dp[num] 구하기 
+			int root = (int)Math.sqrt(i);
+			int min = Integer.MAX_VALUE;
+			for(int j=root; j>0; j--) { // dp[i] 내에서 가능한 제곱들 다 뺴보기 
+				int remain = i - j*j;
+				min = min<dp[remain]+1 ? min : dp[remain]+1;
+			}
+			dp[i]=min;
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		// 입력 
+		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(bf.readLine());
+		
+		// 초기화 
+		dp = new int[N+1];
+		dp[0] = 0;
+		dp[1] = 1;
+		
+		// dp 배열 구하기 
+		DP(N);
+		
+		// 출력 
+		System.out.println(dp[N]);
+	}
+
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B16948번 데스나이트
최소 이동 횟수를 구해야하므로 BFS를 사용한다.
이동 방향은 dr{-2, -2, 0, 0, 2, 2}, dc{-1,1,-2,2,-1,1}이다.
(r1, c1)에서 시작하여 (r2, c2)를 만날 때까지 BFS로 탐색하고 이동 거리를 출력한다.

##### B17298번 오큰수
저번에 풀었던 탑 문제와 유사하다. 수열을 입력받으면서 현재값보다 작은 값을 전부 꺼내는 방식이다.

1. 스택에는 수열의 {값, 인덱스}가 저장된다.
2. 결과 배열은 -1로 초기화한다.
3. 수열을 입력받으면서 스택에 현재값보다 작은 값이 있을 경우, 꺼내서 결과 배열 그 값 위치에 현재값을 저장한다. 
4. 현재값보다 작은 값은 전부 pop되므로 입력이 종료되면 스택에는 오큰수를 구하지 못 한 값들만 남게 된다.
5. 결과 배열을 출력한다.

-> 더 이상 줄일 방법이 없는 것 같은데 계속 시간초과가 났다... for문으로 print돌리던걸 StringBuilder로 바꿔서 출력하니까 해결됨 ㅠ

##### B17626번 Four Squares
처음에는 제곱수 합의 개수를 출력하는 DP 메소드를 만들어서 DP(현재값) = min(DP(현재값-i제곱) + 1) 형식으로 돌리고 제곱수 합이 4를 넘어가면 멈추게 했다. 답은 나오는데 아무리 고쳐도 시간 초과가 뜨길래 풀이를 찾아봤다. 현재값-i제곱에 1을 더하는 방식은 맞지만, 배열을 이용해서 이미 구한 값은 또 구하지 않게 하는 것이 시간 단축의 핵심이었다.
1. 점화식을 위해 dp[0] = 0, dp[1] =1로 초기화시켜준다.
2. dp[2]부터 dp[N]을 구하는 for문을 돌린다.
3. dp[i]는 min(dp[i-제곱]+1)이다.
7. dp[N]을 출력한다.

<hr>

### 🤯 이슈 & 질문
