### PR TITLE
[week4] B13549_숨바꼭질3, B14501_퇴사, (미해결)P42895_N으로표현

### DIFF
--- a/윤상우/Week_4/B13549_숨바꼭질3.java
+++ b/윤상우/Week_4/B13549_숨바꼭질3.java
@@ -1,0 +1,73 @@
+package temp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B13549_숨바꼭질3 {
+
+    static int n;
+    static int k;
+    static int dp [];
+    static boolean isVisited [];
+    static int dx [] = {+1, -1, 2};
+
+    static boolean isValid(int n){
+        if(n < 0 || n >= dp.length) return false;
+        return true;
+    }
+
+    static void bfs(int n){
+        Queue<Integer> queue = new ArrayDeque<>();
+        queue.offer(n);
+        dp[n] = 0;
+        if(n == k) return;
+        isVisited[n] = true;
+
+        while(!queue.isEmpty()){
+            int now = queue.poll();
+            if(isVisited[k]) break;
+
+            for(int i=2; i>=0; i--){
+                int next;
+                if(i != 2){
+                    next = now + dx[i];
+                }else{
+                    next = now*dx[i];
+                }
+
+                if(!isValid(next)) continue;
+                if(isVisited[next]) continue;
+
+                queue.offer(next);
+                isVisited[next] = true;
+
+                if(i != 2){
+                    dp[next] = dp[now]+1;
+                }else{
+                    dp[next] = dp[now];
+                }
+
+            }
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        dp = new int [100001];
+        isVisited = new boolean [100001];
+
+        bfs(n);
+
+        System.out.println(dp[k]);
+
+    }
+}

--- a/윤상우/Week_4/B14501_퇴사.java
+++ b/윤상우/Week_4/B14501_퇴사.java
@@ -1,0 +1,44 @@
+package temp;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class B14501_퇴사 {
+
+    static int n;
+    static int [] t;
+    static int [] p;
+    static int [] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+
+        t = new int [n];
+        p = new int [n];
+        dp = new int [n+1];
+
+        for(int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine());
+            t[i] = Integer.parseInt(st.nextToken());
+            p[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for(int i=0; i<n; i++){
+            if(i + t[i] <= n) {
+                dp[i + t[i]] = Math.max(dp[i + t[i]], dp[i] + p[i]);
+            }
+            dp[i+1] = Math.max(dp[i+1], dp[i]);
+        }
+
+        System.out.println(dp[n]);
+
+
+    }
+}

--- a/윤상우/Week_4/P42895_N으로표현.java
+++ b/윤상우/Week_4/P42895_N으로표현.java
@@ -1,0 +1,56 @@
+package temp;
+
+public class P42895_N으로표현 {
+    static int [] array;
+    static int [] dp;
+    static int cnt;
+
+    public static boolean isValid(int n){
+        if(n > 32000 || n < 1) return false;
+        return true;
+    }
+    public static void dfs(int now , int cnt){
+        if(cnt >7) return;
+
+        int next;
+        for(int i : array){
+            if(i == 1){
+                next = now + now;
+                if(!isValid(next)) continue;
+                dp[next] = dp[now] + 1;
+                dfs(next, cnt+1);
+            }else if (i == 2){
+                next = now - now;
+                if(!isValid(next)) continue;
+                dp[next] = dp[now] + 1;
+                dfs(next, cnt+1);
+            }else if (i == 3){
+                next = now * now;
+                if(!isValid(next)) continue;
+                dp[next] = dp[now] + 1;
+                dfs(next, cnt+1);
+            }else if (i == 4){
+                next = now / now;
+                if(!isValid(next)) continue;
+                dp[next] = dp[now] + 1;
+                dfs(next, cnt+1);
+            }else{
+                next = now + 10*now;
+                if(!isValid(next)) continue;
+                dp[next] = dp[now] + 1;
+                dfs(next, cnt+1);
+            }
+        }
+
+    }
+    public int solution(int N, int number) {
+        int answer = 0;
+        dp = new int [32000];
+        array = new int[]{1,2,3,4,5};
+        dp[N] = 1;
+
+        dfs(N,0);
+        answer = dp[number];
+        return answer;
+    }
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B13549_숨바꼭질3
숨바꼭질1과 비슷한 bfs 최단거리 탐색 문제이나, 순간이동시 가중치가 다르고, 각각 스텝의 순서가 중요하게 작용하였다. dx 배열을 [x2,-1,+1] 순서대로 해주어야 해결된다.

##### B14501_퇴사
처음에 그리디로 풀다가 도저히 마지막 테케에서 짤려서 좌절하던 중, 아래 dp 힌트를 보고 다시 시도하였다. dp의 인덱스에 t[i]를 더해주는 점화식은 곧바로 떠올리기 어려웠다,,,!


##### P42985_N으로표현
사칙연산 + 같은 숫자 자리수 추가 총 5개의 경우로 dp 갱신을 해보았지만, 어림없이 실패. 새벽이라 머리가 안돌아가서 코드가 엉망이다...;; 이거는 다시 도전해야 할듯

<hr>

### 🤯 이슈 & 질문
