### PR TITLE
[week6] B2579_계단오르기, B1780_종이의개수

### DIFF
--- a/길민지/Week_6/B1780_종이의개수.java
+++ b/길민지/Week_6/B1780_종이의개수.java
@@ -1,0 +1,52 @@
+import java.util.*; 
+import java.io.*;
+
+class Main {
+  static int N;
+  static int [][] matrix;
+  static int [] cnt; // -1, 0, 1의 개수
+
+  static void cut(int[] start, int n){
+    int num = matrix[start[0]][start[1]]; // 첫번째 숫자
+    boolean isSame = true; // 다 같은 수인지
+    for (int i=0; i<n; i++){
+      for(int j=0; j<n; j++){
+        if (matrix[start[0]+i][start[1]+j] != num){ 
+          isSame = false;
+          break;
+        }
+      }
+    }
+
+    if (isSame){ // 전부 같은 수라면 개수 증가
+      cnt[num+1]+= 1;
+    }
+    else{ // 아니라면 9조각 내서 다시 세기
+      for(int i=0; i<3; i++){
+        for (int j=0; j<3; j++){
+          cut(new int[]{start[0] + i*(n/3), start[1] + j*(n/3)}, n/3);
+        }
+      }
+    }
+  }
+  
+  public static void main(String[] args) throws Exception{
+    BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(bf.readLine());
+
+    N = Integer.parseInt(st.nextToken());
+    matrix = new int[N][N];
+    cnt = new int[3];
+    
+    for(int i=0; i<N; i++){
+      st = new StringTokenizer(bf.readLine());
+      for(int j=0; j<N; j++){
+        matrix[i][j] = Integer.parseInt(st.nextToken());
+      }
+    }
+
+    cut(new int[]{0,0}, N);
+
+    for(int c:cnt) System.out.println(c);
+  }
+}

--- a/길민지/Week_6/B2579_계단오르기.java
+++ b/길민지/Week_6/B2579_계단오르기.java
@@ -17,22 +17,17 @@ class Main {
       score[i] = sc.nextInt();
     }
 
-    // 계단이 1개, 2개, 3개인 경우
+    // 계단이 1개
     if(N==1) {
       System.out.println(score[1]);
-      return;
-    }
-    else if (N==2){
-      System.out.println(score[1] + score[2]);
       return;
     }
 
     // 1층, 2층 세팅
     dp[1][0] = score[1];
-    dp[2][0] = score[1] + score[2];
-    dp[2][1] = score[2];
+    dp[1][1] = score[1];
 
-    for (int i = 3; i < N + 1; i++) {
+    for (int i = 2; i < N + 1; i++) {
       // 1층 아래에서 올라온 경우
       dp[i][0] = Math.max(dp[i][0], dp[i - 1][1] + score[i]);
 

--- a/길민지/Week_6/B2579_계단오르기.java
+++ b/길민지/Week_6/B2579_계단오르기.java
@@ -1,0 +1,47 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+  static int N;
+  static int score[];
+  static int max = 0;
+  static int dp[][]; // [현재 층], [이전에 몇칸 올랐는지] 0 - 1층 / 1 - 2층
+
+  public static void main(String[] args) {
+    // 입력 및 초기화
+    Scanner sc = new Scanner(System.in);
+    N = sc.nextInt();
+    score = new int[N + 1];
+    dp = new int[N + 1][2];
+    for (int i = 1; i < N + 1; i++) {
+      score[i] = sc.nextInt();
+    }
+
+    // 계단이 1개, 2개, 3개인 경우
+    if(N==1) {
+      System.out.println(score[1]);
+      return;
+    }
+    else if (N==2){
+      System.out.println(score[1] + score[2]);
+      return;
+    }
+
+    // 1층, 2층 세팅
+    dp[1][0] = score[1];
+    dp[2][0] = score[1] + score[2];
+    dp[2][1] = score[2];
+
+    for (int i = 3; i < N + 1; i++) {
+      // 1층 아래에서 올라온 경우
+      dp[i][0] = Math.max(dp[i][0], dp[i - 1][1] + score[i]);
+
+      // 2층 아래에서 올라온 경우
+      int m = Math.max(dp[i - 2][0] + score[i], dp[i - 2][1] + score[i]);
+      dp[i][1] = Math.max(dp[i][1], m);
+    }
+
+    System.out.println(Math.max(dp[N][0], dp[N][1]));
+
+  }
+}

--- a/길민지/Week_6/B2579_계단오르기.java
+++ b/길민지/Week_6/B2579_계단오르기.java
@@ -17,13 +17,13 @@ class Main {
       score[i] = sc.nextInt();
     }
 
-    // 계단이 1개
+    // 계단이 1개인 경우
     if(N==1) {
       System.out.println(score[1]);
       return;
     }
 
-    // 1층, 2층 세팅
+    // 1층 세팅
     dp[1][0] = score[1];
     dp[1][1] = score[1];
 


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B2579 계단오르기
완전탐색으로 풀었더니 시간초과 났다.
1층은 무조건 1층의 점수이며 이후의 계단들은 1층 밑 또는 2층 밑에서만 올라온다는 점에서 DP를 떠올렸다고 하고싶지만 사실 선영언니가 DP 얘기하길래 이미 알고있었다ㅎㅎ;
저번 단계에서 1층을 오른 경우 이번 단계에서는 1층을 오를 수 없기 때문에 구분해서 처리해주는게 어려웠음
그래서 1층 올라서 얻은 최대 점수와 2층 올라서 얻은 최대 점수를 따로 기록하기로 했다.

1. 1층의 점수를 세팅해줍니다.
2. 2층부터 N층까지 각 최대 점수를 구합니다.
- dp[i][0]은 1층 아래에서 올라온 경우의 점수를 저장합니다. 3층 연속으로 밟을 수 없으므로 무조건 이전 단계에선 2층 오른 경우(dp[i-1][1])의 점수로만 계산합니다.
- dp[i][1]은 2층 아래에서 올라온 경우의 점수를 저장합니다. 이전 단계에서는 몇층을 올랐든지 상관 없으므로 dp[i-2][0], dp[i-2][1] 둘 다 계산해서 더 큰 값으로 넣어줍니다.
3. 최종적으로 dp[N][0], dp[N][1] 중 큰 값을 출력합니다.

##### B1780 종이의 개수
전체가 같은 숫자인지 확인합니다.
-> 같다면 현재 숫자의 카운트를 증가합니다.
-> 같지 않다면 9등분해서 다시 확인합니다.


<hr>

### 🤯 이슈 & 질문
아싸 일뜽
