### PR TITLE
[Week7] B17281_야구, B1932_정수삼각형, P42577_전화번호목록 

### DIFF
--- a/신선영/Week_6/B1780_종이의개수.py
+++ b/신선영/Week_6/B1780_종이의개수.py
@@ -1,0 +1,26 @@
+# [BOJ] 1780. 종이의 개수
+import sys
+input = sys.stdin.readline
+
+
+def cut(i, j, n):
+    curN = L[i][j]  # 시작점의 값
+    for ii in range(i, i + n):
+        for jj in range(j, j + n):
+            if L[ii][jj] != curN:
+                # 아닌 부분을 만나면 무조건 3분할
+                for x in range(3):
+                    for y in range(3):
+                        cut(i + x * (n // 3), j + y * (n // 3), n // 3)
+                return
+    ans[curN + 1] += 1
+    
+
+N = int(input())
+L = [list(map(int, input().split())) for _ in range(N)]
+
+ans = [0, 0, 0]   # -1, 0, 1
+cut(0, 0, N)
+
+for a in ans:
+    print(a)

--- a/신선영/Week_6/B2579_계단오르기.java
+++ b/신선영/Week_6/B2579_계단오르기.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());   // 전체 계단의 수
+
+        int[] stairs = new int[N];
+        int[] DP = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            stairs[i] = Integer.parseInt(st.nextToken());
+        }
+
+//        System.out.println(Arrays.toString(stairs));
+
+        // 전체 계단이 3개가 안되는 경우 예외 처리
+        if (N <= 2) {
+            int sum = 0;
+            for (int i = 0; i < N; i++) {
+                sum += stairs[i];
+            }
+
+            System.out.println(sum);
+        }
+
+        else {
+            DP[0] = stairs[0];
+            DP[1] = stairs[0] + stairs[1];
+            // 1, 2, 3을 모두 밟을 수는 없음
+            DP[2] = Math.max(stairs[1] + stairs[2], stairs[0] + stairs[2]);
+
+            for (int i = 3; i < N; i++) {
+                // 바로 이전 칸을 밟지 않을 경우와 이전 칸을 밟는 경우 비교
+                DP[i] = Math.max(DP[i - 2] + stairs[i], DP[i - 3] + stairs[i - 1] + stairs[i]);
+            }
+            System.out.println(DP[N - 1]);
+        }
+
+    }
+}

--- a/신선영/Week_7/B17281_야구.py
+++ b/신선영/Week_7/B17281_야구.py
@@ -1,0 +1,102 @@
+import sys
+input=sys.stdin.readline
+from itertools import permutations
+
+
+def play(ord):  # ord: 타순
+    ord.insert(3, 0)
+    score = 0
+    inn = 0  # 현재 이닝
+    cur = 0  # 현재 타순
+    board = [0, 0, 0]  # 1루, 2루, 3루
+    out = 0
+
+    while inn < N:  # 최대 이닝 전까지 진행
+        # out 3개 이하인 경우 경기 진행
+        # 경기 진행 과정
+        res = R[inn][ord[cur]]
+
+        if res == 0:   # 아웃
+            out += 1
+          
+        elif res == 1:  # 안타
+            if board[2] == 1:  # 3루에 주자 있는 경우
+                score += 1
+                board[2] = 0
+            if board[1] == 1:  # 2루에 주자 있는 경우
+                board[2] = 1
+                board[1] = 0
+            if board[0] == 1:  # 1루에 주자 있는 경우
+                board[1] = 1
+                board[0] = 0
+            board[0] = 1  # 타자 진루
+          
+        elif res == 2:  # 2루타 (2, 3루 득점 가능)
+            if board[2] == 1:  # 3루에 주자 있는 경우
+                score += 1
+                board[2] = 0
+            if board[1] == 1:  # 2루에 주자 있는 경우
+                score += 1
+                board[1] = 0
+            if board[0] == 1:  # 1루에 주자 있는 경우
+                board[2] = 1
+                board[0] = 0
+            board[1] = 1  # 타자 진루 (2루)
+    
+        elif res == 3:  # 3루타 (1, 2, 3루 득점 가능)
+            if board[2] == 1:  # 3루에 주자 있는 경우
+                score += 1
+                board[2] = 0
+            if board[1] == 1:  # 2루에 주자 있는 경우
+                score += 1
+                board[1] = 0
+            if board[0] == 1:  # 1루에 주자 있는 경우
+                score += 1
+                board[0] = 0
+            board[2] = 1  # 타자 진루 (3루)
+    
+        elif res == 4:  # 홈런
+            if board[2] == 1:
+                score += 1
+                board[2] = 0
+            if board[1] == 1:
+                score += 1
+                board[1] = 0
+            if board[0] == 1:
+                score += 1
+                board[0] = 0
+            score += 1
+          
+            ''' 이렇게 하면 시간초과
+            score += board.count(1) + 1  # 타자 포함 모두 득점
+            board = [0, 0, 0]
+            '''
+    
+        
+
+        cur += 1
+        if cur == 9:
+            cur = 0
+            
+
+        # out이 3개 되는 순간 다음 이닝
+        if out == 3:
+            out = 0
+            board = [0, 0, 0]
+            inn += 1
+
+    return score
+    
+    
+        
+
+N = int(input())  # 이닝 수 (2 <= N <= 50)
+L = permutations([1, 2, 3, 4, 5, 6, 7, 8], 8)
+
+R = [list(map(int, input().split())) for _ in range(N)]
+
+ans = 0
+for l in L:
+    ans = max(ans, play(list(l)))
+
+print(ans)

--- a/신선영/Week_7/B1932_정수삼각형.py
+++ b/신선영/Week_7/B1932_정수삼각형.py
@@ -1,0 +1,16 @@
+import sys
+input=sys.stdin.readline
+
+N=int(input())  # 삼각형의 크기
+DP = [[] for _ in range(N)]
+DP[0].append(int(input()))
+
+
+for i in range(1, N):
+    L = list(map(int, input().split()))
+    DP[i].append(DP[i - 1][0] + L[0])
+    for j in range(1, len(L) - 1):
+        DP[i].append(max(DP[i - 1][j - 1] + L[j], DP[i - 1][j] + L[j]))
+    DP[i].append(DP[i - 1][-1] + L[-1])
+
+print(max(DP[-1]))

--- a/신선영/Week_7/P42577_전화번호목록.py
+++ b/신선영/Week_7/P42577_전화번호목록.py
@@ -1,0 +1,18 @@
+def solution(phone_book):
+    answer = True
+
+    # 시작하는 숫자와 길이 두 가지 기준으로 정렬
+    phone_book = sorted(phone_book, key= lambda x: (len, x))
+
+
+    for i in range(len(phone_book) - 1):
+        if answer == False:
+            break
+        else: 
+            txt = phone_book[i]
+            l = len(txt)
+            # 정렬이 완료된 상태이기 때문에 바로 뒤의 값만 확인해도 됨
+            if phone_book[i + 1][:l] == txt:
+                answer = False
+
+    return answer


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B17281_야구
승규랑 같은 방식으로 permutations으로 가능한 모든 타순 배열 구해서 냅다 구현 함수 돌림
python 말고 pypy로만 되는 문제라는데 승규랑 코드 거의 같은데도 자꾸 시간초과 떠서 봤더니
홈런인 경우 현재 진루 상황 나타내는 배열에서 True(1)값을 count 메소드 이용해서 그 개수만큼 점수 더하려고 했더니 시간초과 뜨고 
if문으로 현재 진루 상황 하나하나 돌려서 점수 입력했더니 시간초과 안남 짱나

##### B1932_정수삼각형 / DP
예제와 같이 
7
3 8
8 1 0
2 7 4 4
4 5 2 6 5
같은 삼각형이 있다면
7
10 15
18 16 15 ...
와 같이 현재까지의 최대값만을 저장한 새로운 배열을 생성하는 방식
그러기 위해서는 DP배열(현재 위치 윗줄)의 i-1번째 인덱스와 i번째 인덱스에 현재 위치 값을 더해서 비교하기만 하면 된다
![image](https://github.com/KB-team3/AlgoGGang/assets/97646668/25c6a587-f046-4593-99ce-6d1619766442)
대략 이런 느낌..


##### P42577_전화번호목록
입력받은 배열을 처음에는 길이로만 정렬해서 이중for문으로 돌렸더니 시간초과 (효율성 3, 4)
lambda를 이용해서 길이, 숫자 값을 모두 이용해서 정렬하면
정렬된 배열 현재 위치의 다음 값이 현재 값으로 시작하는지만 확인하면 된다

<hr>

### 🤯 이슈 & 질문
