### PR TITLE
[Week8] B2293_동전1, B2564_경비원, B9081_단어맞추기

### DIFF
--- a/길민지/Week_8/B2293_동전1.java
+++ b/길민지/Week_8/B2293_동전1.java
@@ -1,0 +1,35 @@
+import java.util.Scanner;
+
+public class B2293_동전1 {
+    static int n, k;
+    static int[] value;
+    static int[] dp;
+
+    public static void init(){
+        Scanner sc = new Scanner(System.in);
+        n = sc.nextInt();
+        k = sc.nextInt();
+        value = new int[n];
+        dp = new int[k+1];
+        for(int i=0; i<n; i++){
+            value[i] = sc.nextInt();
+        }
+    }
+
+    public static void solution(){
+        for(int i=0; i<n; i++){
+            int coin = value[i];
+            if(coin>k) continue; // k보다 동전의 가치가 큰 경우 확인 X
+            dp[coin]+=1;
+            for(int j=coin+1; j<k+1; j++){ // dp 갱신
+                dp[j]=dp[j]+dp[j-coin];
+            }
+        }
+    }
+
+    public static void main(String args[]){
+       init();
+       solution();
+       System.out.println(dp[k]);
+    }
+}

--- a/길민지/Week_8/B2564_경비원.java
+++ b/길민지/Week_8/B2564_경비원.java
@@ -1,0 +1,76 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class B2564_경비원 {
+    static int W, H;
+    static int N;
+    static int stores[][];
+    static int dg[];
+    static int result;
+
+    public static void init() throws Exception{
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+
+        // 가로 세로 상점개수
+        W = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(bf.readLine());
+        N = Integer.parseInt(st.nextToken());
+
+        // 가게
+        stores = new int[N][2];
+        for(int i=0; i<N; i++){
+            st = new StringTokenizer(bf.readLine());
+            stores[i][0] = Integer.parseInt(st.nextToken());
+            stores[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        // 동근
+        st = new StringTokenizer(bf.readLine());
+        dg = new int[2];
+        dg[0] = Integer.parseInt(st.nextToken());
+        dg[1] = Integer.parseInt(st.nextToken());
+    }
+
+    public static void solution(){
+        for(int i=0; i<N; i++){
+            int  dir = stores[i][0];
+            int  pos = stores[i][1];
+
+            if (dir == dg[0]){ // 둘이 같은 방향에 있을 때
+                result += Math.abs(pos-dg[1]);
+            }
+            else if ((dir == 1 && dg[0] == 2) || (dir == 2 && dg[0] == 1)){ // 북&남
+                result += H+Math.min(pos+dg[1], 2*W-pos-dg[1]);
+            }
+            else if ((dir == 3 && dg[0] == 4) || (dir == 4 && dg[0] == 3)){ // 동&서
+                result += W+Math.min(pos+dg[1], 2*H-pos-dg[1]);
+            }
+            else if (dg[0] == 1){ // 동근 북
+                if (dir == 3) result += dg[1]+pos; // 상점 서
+                else result += W-dg[1]+pos; // 상점 동
+            }
+            else if (dg[0] == 2){ // 동근 남
+                if (dir == 3) result += dg[1]+H-pos; // 상점 서
+                else result += W-dg[1]+H-pos; // 상점 동
+            }
+            else if (dg[0] == 3){ // 동근 서
+                if (dir == 1) result += dg[1]+pos; // 상점 북
+                else result += H-dg[1]+pos; // 상점 남
+            }
+            else if (dg[0] == 4){ // 동근 동
+                if (dir == 1) result += dg[1]+W-pos; // 상점 북
+                else result += W-dg[1]+pos; // 상점 남
+            }
+        }
+    }
+
+    public static void main(String args[]) throws Exception{
+        init();
+        solution();
+        System.out.println(result);
+    }
+}

--- a/길민지/Week_8/B9081_단어맞추기.java
+++ b/길민지/Week_8/B9081_단어맞추기.java
@@ -31,11 +31,8 @@ public class B9081_단어맞추기 {
                             break;
                         }
                     }
-                    char[] sort = Arrays.copyOfRange(word, i+1, word.length);
-                    Arrays.sort(sort); // 뒷부분 정렬
-                    System.arraycopy(sort, 0, word, i+1, word.length-1-i);
-                    String rs = new String(word);
-                    System.out.println(rs); // 출력
+                    Arrays.sort(word, i+1, word.length); // 뒷부분 정렬
+                    System.out.println(new String(word)); // 출력
                     break;
                 } else {
                     now = i;

--- a/길민지/Week_8/B9081_단어맞추기.java
+++ b/길민지/Week_8/B9081_단어맞추기.java
@@ -1,0 +1,52 @@
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Scanner;
+
+public class B9081_단어맞추기 {
+    static int N;
+    static String input[];
+    public static void init(){
+        Scanner sc = new Scanner(System.in);
+        N = Integer.parseInt(sc.nextLine());
+
+        input = new String[N];
+        for(int i=0; i<N; i++){
+            input[i] = sc.nextLine();
+        }
+    }
+    public static void solution(){
+        for(String s:input){
+            boolean isLast = true;
+            char[] word = s.toCharArray();
+
+            int now = word.length-1;
+            for(int i=word.length-2; i>=0; i--){ // 뒤에서부터 체크
+                if(word[i]<word[now]){ // 감소 시
+                    isLast = false;
+                    char temp = word[i];
+                    for(int j=word.length-1; j>i; j--){
+                        if(word[j]>temp){ // 바꿀 단어보다 더 큰 단어 나오면 교체
+                            word[i] = word[j];
+                            word[j] = temp;
+                            break;
+                        }
+                    }
+                    char[] sort = Arrays.copyOfRange(word, i+1, word.length);
+                    Arrays.sort(sort); // 뒷부분 정렬
+                    System.arraycopy(sort, 0, word, i+1, word.length-1-i);
+                    String rs = new String(word);
+                    System.out.println(rs); // 출력
+                    break;
+                } else {
+                    now = i;
+                }
+            }
+            if(isLast) System.out.println(s); // 마지막 단어인 경우
+        }
+    }
+
+    public static void main(String args[]){
+        init();
+        solution();
+    }
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B2293 동전 1
DP라는건 알았는데 쉽지 않았다...
처음 시도한 방법은 
![KakaoTalk_Photo_2023-06-19-03-10-50](https://github.com/KB-team3/AlgoGGang/assets/78344310/104d21dc-c2f4-4c45-8d25-0796431ed304)
이렇게 동전별로 개수를 담은 배열을 가치별로 hashset에 담아 차례차례 저장하는 방법이었는데 해시를 써도 안에 들어있는게 배열이라 중복 체크가 안 돼서 실패했음ㅎㅎ

<img width="137" alt="스크린샷 2023-06-19 오전 3 15 53" src="https://github.com/KB-team3/AlgoGGang/assets/78344310/781dd618-f47b-49fb-95b9-9f56728a2d74"> | <img width="210" alt="스크린샷 2023-06-19 오전 3 16 04" src="https://github.com/KB-team3/AlgoGGang/assets/78344310/03fb200b-3caa-481b-81cf-57e8034d24ef"> | <img width="179" alt="스크린샷 2023-06-19 오전 3 16 07" src="https://github.com/KB-team3/AlgoGGang/assets/78344310/1a7d8d29-44c3-4fa8-b940-88dcd13a3479"> 
| --- | --- | --- |

이렇게 다 써보니까 동전 한개를 뺀 거에 해당 동전을 추가하면 원하는 가치가 나온다는건 알았는데 중복을 걸러내는 방법을 못 찾았음....
결국 아이디어는 검색해서 알아냈다.

1. 동전별로 돌면서 dp를 채워준다.
2. 해당 동전 1개 쓰는 경우 추가해주기 (dp[coin]+=1)
3. 나머지는 dp[j] = dp[j]+dp[j-coin] (해당 동전의 가치를 뺀 값에 해당 동전 1개만 추가해주면 해당 가치가 완성되기 때문)
4. 아래처럼 됩니당
![KakaoTalk_Photo_2023-06-19-03-27-49](https://github.com/KB-team3/AlgoGGang/assets/78344310/45d2f25a-ccdf-4406-8072-66aff0eddcca)

##### B2564 경비원
그냥 분기 나눠서 구하면 되는 문제였다. 더 깔끔하게 정리할 수 있는 방법이 궁금함
1. 동근이와 가게가 같은 방향에 있을 경우 위치 차이의 절대값 추가
5. 동근이와 가게가 북/남에 있는 경우 오른쪽 or 왼쪽 중 짧은 값 + 세로 길이 추가
6. 동근이와 가게가 동/서에 있는 경우 윗쪽 or 아래쪽 중 짧은 값 + 가로 길이 추가
7. 그 외는 동근이와 가게가 인접한 방향에 있으므로 각각 길이 구해서 추가

##### B9081 단어 맞추기
단어를 사전순으로 쭉 나열하다가 원본 문자열 찾으면 그 다음꺼 출력하는 방법으로 풀었는데 메모리 초과나서 실패했다.
결국 새로운 방법 못 찾고 검색해봤는데 주어진 문자열만 확인해서 다음 단어를 찾아내는 방법이었다.

1. 단어의 맨뒤부터 역순으로 검사해서 감소하는 알파벳이 나오면 체크한다.
2. 맨뒤부터 역순으로 검사해서 해당 알파벳보다 큰 알파벳이 나오면 둘이 교체한다.
3. 교환된 알파벳 뒷부분을 정렬한다.

+ Arrays.sort에 범위 지정하는게 있는줄 몰라서 새로 배열 만들어서 복사하는 방법 썼는데 상우오빠 코드 보고 수정했음ㅎ

<hr>

### 🤯 이슈 & 질문
ㅠㅠ검색하는거 너무 자존심 상하는데,,, 최대한 아이디어만 조금 보고 직접 구현하려고 노력은 함
그래도 아쉽다