### PR TITLE
[Week10] B13460_구슬탈출2, B2212_센서, B11048_이동하기

### DIFF
--- a/이우엽/Week_10/B11048_이동하기.java
+++ b/이우엽/Week_10/B11048_이동하기.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B11048_이동하기 {
+	static int N;
+	static int M;
+	static int[][] arr2d;
+	static int[][] result;
+	static int[] dx = {1, 0, 1};
+	static int[] dy = {0, 1, 1};
+	
+	public static void print() {
+		System.out.println();
+		for(int i = 0; i < N; i++) {
+			System.out.println(Arrays.toString(result[i]));
+		}
+	}
+	public static void accSum(int x, int y) {
+//		print();
+		for(int i = 0; i < 3; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			if(nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+//			System.out.println("nx: " + nx + ", ny: " + ny);
+			if(result[nx][ny] == 0) {
+				result[nx][ny] = result[x][y] + arr2d[nx][ny];
+			} else {
+				result[nx][ny] = Math.max(result[nx][ny], result[x][y] + arr2d[nx][ny]);
+			}
+			
+			accSum(nx, ny);
+		}
+	}
+	public static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer token = new StringTokenizer(br.readLine(), " ");
+		N = Integer.parseInt(token.nextToken());
+		M = Integer.parseInt(token.nextToken());
+		
+		arr2d = new int[N][M];
+		result = new int[N][M];
+		for(int i = 0; i < N; i++) {
+			token = new StringTokenizer(br.readLine(), " ");
+			for(int j = 0; j < M; j++) {
+				arr2d[i][j] = Integer.parseInt(token.nextToken());
+			}
+		}
+	}
+	public static void main(String[] args) throws IOException {
+		init();
+//		for(int i = 0; i < N; i++) {
+//			System.out.println(Arrays.toString(arr2d[i]));
+//		}
+		result[0][0] = arr2d[0][0];
+		accSum(0,0);
+//		print();
+		System.out.println(result[N-1][M-1]);
+	}
+}

--- a/이우엽/Week_10/B13460_구슬탈출2.java
+++ b/이우엽/Week_10/B13460_구슬탈출2.java
@@ -1,0 +1,107 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B13460_구슬탈출2 {
+	static int N;
+	static int M;
+	static char[][] arr2d;
+	static int[] dx = {-1, 0, 1, 0};
+	static int[] dy = {0, 1, 0, -1};
+	static int flag = 1;
+	
+	public static void print() {
+		for(int i = 0; i < N; i++) {
+			System.out.println(Arrays.toString(arr2d[i]));
+		}
+	}
+	public static void implement(int[] locR, int[] locB, int[] target) {
+		int xr = locR[0];
+		int yr = locR[1];
+		
+		int xb = locB[0];
+		int yb = locB[1];
+		boolean[][] isVisited = new boolean[N][M];
+		Queue<int[]> queue = new ArrayDeque<>();
+		isVisited[xr][yr] = true;
+		queue.offer(new int[]{xr, yr});
+		while(!queue.isEmpty()) {
+			int[] cur = queue.remove();
+			
+			for(int i = 0; i < 1; i++) {
+				int nx = cur[0] + dx[i];
+				int ny = cur[1] + dy[i];
+				
+				int nx_b = xb + dx[i];
+				int ny_b = yb + dy[i];
+				
+				if(arr2d[nx][ny] == '#') continue;
+				while(arr2d[nx][ny] == '.' && !isVisited[nx][ny]) {
+					if(arr2d[nx_b][ny_b] == 'O') {
+						flag = 0;
+						return;
+					}
+					
+					if(arr2d[nx][ny] == 'O') {
+						break;
+					}
+					isVisited[nx][ny] = true;
+					queue.offer(new int[]{nx, ny});
+					
+					nx = cur[0] + dx[i];
+					ny = cur[1] + dy[i];
+					
+					if(arr2d[nx_b][ny_b] != '#') {
+						nx_b = nx_b + dx[i];
+						ny_b = ny_b + dy[i];
+					}
+				}
+				arr2d[nx][ny] = 'R';
+			}
+			print();
+			System.out.println();
+		}
+	}
+	public static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer token = new StringTokenizer(br.readLine(), " ");
+		N = Integer.parseInt(token.nextToken());
+		M = Integer.parseInt(token.nextToken());
+		
+		arr2d = new char[N][M];
+		for(int i = 0; i < N; i++) {
+			String arr = br.readLine();
+			arr2d[i] = arr.toCharArray();
+		}
+	}
+	public static void main(String[] args) throws IOException {
+		init();
+		
+		//R, B, O 위치 찾기
+		int[] locR = new int[2];
+		int[] locB = new int[2];
+		int[] locO = new int[2];
+		for(int i = 0; i < N; i++) {
+			for(int j = 0; j < M; j++) {
+				if(arr2d[i][j] == 'R') {
+					locR[0] = i;
+					locR[1] = j;
+				} else if(arr2d[i][j] == 'B') {
+					locB[0] = i;
+					locB[1] = j;
+				} else if(arr2d[i][j] == 'O') {
+					locO[0] = i;
+					locO[1] = j;
+				}
+			}
+		}
+		
+		System.out.println("R:" + locR[0] + " " + locR[1]);
+		System.out.println("B:" + locB[0] + " " + locB[1]);
+		implement(locR, locB, locO);
+	}
+}

--- a/이우엽/Week_10/B2212_센서.java
+++ b/이우엽/Week_10/B2212_센서.java
@@ -1,0 +1,65 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+class SensorInfo implements Comparable<SensorInfo> {
+	int gap;
+	int idx;
+	
+	SensorInfo(int gap, int idx) {
+		this.gap = gap;
+		this.idx = idx;
+	}
+	
+	public String toString() {
+		return idx + ": " + gap;
+	}
+	
+	public int compareTo(SensorInfo o) {
+		return o.gap - this.gap;
+	}
+} 
+public class B2212_센서 {
+	static int N;
+	static int K;
+	static int[] sensors;
+	static SensorInfo[] sArr;
+	static SensorInfo[] result;
+	
+	public static void cal() {
+		for(int i = sensors.length-1; i > 0; i--) {
+			int gap = sensors[i] - sensors[i-1];
+			SensorInfo info =  new SensorInfo(gap, i);
+			sArr[i] = info;
+		}
+		
+		Arrays.sort(sArr, 1, sArr.length);
+		System.out.println(Arrays.toString(sArr));
+		
+		result = Arrays.copyOfRange(sArr, 1, 1 + (K-1));
+		System.out.println(Arrays.toString(result));
+	}
+	public static void init() throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		K = Integer.parseInt(br.readLine());
+		
+		sensors = new int[N];
+		StringTokenizer token = new StringTokenizer(br.readLine(), " ");
+		for(int i = 0; i < N; i++) {
+			sensors[i] = Integer.parseInt(token.nextToken());
+		}
+		
+		sArr = new SensorInfo[N];
+	}
+	public static void main(String[] args) throws NumberFormatException, IOException {
+//		3  67  8  10  12  1415  18  20
+		init();
+		Arrays.sort(sensors);
+		System.out.println(Arrays.toString(sensors));
+		
+		cal();	
+	}
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B13460_구슬탈출2
R이 O까지 가는 최소 움직인 횟수를 구하는 것임으로 BFS를 이용해서 구해야겠다는 생각을 했다.
근데, 기울일때 그 방향으로 .이 있는 만큼 이동해야하는 것까지는 구현을 했으나,
아직 더 구현해야 한다.

##### B2212_센서
n개를 k개의 덩어리로 나누는 문제여서
일단,  센서가 위치한 값을 오름차순 정렬하고, 각각의 gap을 구해서
gap이 큰 순서대로 내림차순 정렬해서,
k-1개만큼 앞에서 잘라줘서
해당 차이가 나는 곳을 잘라주면 
집중국의 수신가능영역의 합을 최소화시킬 수 있다.

##### B11048_이동하기/DFS
1,1 부터 N, M까지 갈 수 있는 모든 경로를 탐색해
result라는 이차원 배열에 해당 경로로 갔을 시, 누적합을 구해주는 방식으로 풀었다.

<hr>

### 🤯 이슈 & 질문

##### B13460_구슬탈출2
R과 B가 같은 줄(혹은 칸에)있을 때, 움직이는 방향쪽으로 상대적으로 더 가까운 공이 먼저 움직여야하는데
그 구현 방식을 잘 모르겠다.

##### B2212_센서
잘라야하는 인덱스까진 구했는데,
잘라야하는 곳이 2개 이상일때 어떻게 잘라야하는지 더 생각해봐야할 것 같다.

##### B11048_이동하기
시간초과가 나는데 왜나는지 모르겠다.