### PR TITLE
[Week10] B13460_구슬탈출2, B2212_센서, B11048_이동하기

### DIFF
--- a/길민지/Week_10/B11048_이동하기.java
+++ b/길민지/Week_10/B11048_이동하기.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class B11048_이동하기 {
+    static int N, M;
+    static int maze[][];
+    static int temp[][];
+    public static void init() throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        maze = new int[N+1][M+1];
+        temp = new int[N+1][M+1];
+        for(int i=1; i<N+1; i++){
+            st = new StringTokenizer(bf.readLine());
+            for (int j=1; j<M+1; j++){
+                maze[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+
+    public static void solution(){
+        for(int i=1; i<N+1; i++){
+            for(int j=1; j<M+1; j++){
+                int m1 = Math.max(temp[i-1][j], temp[i][j-1]);
+                int m2 = Math.max(m1, temp[i-1][j-1]);
+                temp[i][j] = m2 + maze[i][j];
+            }
+        }
+    }
+
+    public static void main(String args []) throws IOException{
+        init();
+        solution();
+        System.out.println(temp[N][M]);
+    }
+}

--- a/길민지/Week_10/B13460_구슬탈출2.java
+++ b/길민지/Week_10/B13460_구슬탈출2.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class B13460_구슬탈출2 {
+    static int N, M;
+    static char[][] board;
+    static int[] di = {1,-1,0,0};
+    static int[] dj = {0,0,1,-1};
+    public static void init() throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        board = new char[N][M];
+        for(int i=0; i<N; i++){
+            String line = bf.readLine();
+            for (int j=0; j<M; j++){
+                board[i][j] = line.charAt(j);
+            }
+        }
+    }
+
+    public static void solution(){
+
+    }
+
+
+    public static void main(String args[]) throws IOException {
+        init();
+        solution();
+    }
+}

--- a/길민지/Week_10/B2212_센서.java
+++ b/길민지/Week_10/B2212_센서.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class B2212_센서 {
+    static int N, K;
+    static int sensor[];
+    static int dist[];
+    static int result;
+
+    public static void init() throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        N = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(bf.readLine());
+        K = Integer.parseInt(st.nextToken());
+
+        sensor = new int[N];
+        st = new StringTokenizer(bf.readLine());
+        for(int i=0; i<N; i++){
+            sensor[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    public static void solution(){
+        // 정렬
+        Arrays.sort(sensor);
+
+        // 센서 사이 거리 구하기
+        dist = new int[N-1];
+        for(int i=1; i<N; i++){
+            dist[i-1] = sensor[i] - sensor[i-1];
+        }
+
+        // 작은 거리부터 더하기 (집중국 개수만큼 빼고)
+        Arrays.sort(dist);
+        for(int i=0; i<N-K;i++){
+           result+=dist[i];
+        }
+    }
+
+    public static void main(String args[]) throws IOException{
+        init();
+        solution();
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B13460_구슬탈출2
돈내고 퇴근 후에 풀겠습니다... 

##### B2212_센서
처음에는 조합으로 센서 위치 정하고 수신 영역의 합 구해서 최소값 구하는 방법을 썼는데 시간초과 났다.
생각해보니 센서 간 거리를 다 더하되, 집중국의 개수만큼 가장 긴 거리가 빠지면 됐음
![KakaoTalk_Photo_2023-07-03-03-13-51](https://github.com/KB-team3/AlgoGGang/assets/78344310/9decb490-4792-48ec-b3b9-ca0d3173a3eb)

1. 센서 위치 정렬
2. 센서 간 거리 구하고 정렬
3.  센서 간 거리를 가장 긴 K-1개 제외하고 더하기
(코드는 이렇게 썼는데 그냥 마지막센서-첫번째센서 하고 긴 거리 K-1개 빼는게 더 효율적일 듯)

##### B11048 이동하기
처음에 쓸 데 없이 DFS, BFS로 도전했다가 각각 시간초과, 메모리초과나서 실패했다.
이동할 수 있는 방법이 오른쪽, 아래, 대각선아래 밖에 없기 때문에 복잡한 이동이 일어날 일이 없으므로 DP를 사용하면 된다.
1. maze 배열에 사탕 개수를 기록한다.
2. 왼쪽, 위, 대각선왼쪽위 세 칸 중에서 가장 큰 수와 현재 칸의 수를 더해 배열 temp를 만든다.
3. temp에는 항상 최댓값이 담기므로 temp[N][M]을 출력한다.

<hr>

### 🤯 이슈 & 질문
