### PR TITLE
[Week10] B13460_구슬탈출2, B2212_센서, B11048_이동하기

### DIFF
--- a/김준서/Week_10/B11048.py
+++ b/김준서/Week_10/B11048.py
@@ -1,0 +1,18 @@
+N, M = map(int, input().split(" "))
+board = []
+dp = [[0 for _ in range(M+1)] for _ in range(N+1)]
+for _ in range(N):
+    board.append(list(map(int,input().split(" "))))
+sumx = board[0][0]
+sumy = board[0][0]
+dp[0][0]=board[0][0]
+for i in range(1,N):
+    sumx+=board[i][0]
+    dp[i][0]+=sumx
+for i in range(1,M):
+    sumy+=board[0][i]
+    dp[0][i]+=sumy
+for i in range(1,N):
+    for j in range(1,M):
+        dp[i][j]=max(dp[i-1][j],dp[i][j-1])+board[i][j]
+print(dp[N-1][M-1])

--- a/김준서/Week_10/B13460.py
+++ b/김준서/Week_10/B13460.py
@@ -1,0 +1,92 @@
+import copy
+from collections import deque
+N, M = map(int,input().split(" "))
+board = [["_" for _ in range(M)] for _ in range(N)]
+for i in range(N):
+    temp = input()
+    board[i] = [t for t in temp]
+#갈 수 있으면 1, 구멍에 들어갔으면 2, 다른거 지나갔으면 3, 못가면 0
+def isOk(board, loc):
+    if board[loc[0]][loc[1]]=='.':
+        return 1
+    elif board[loc[0]][loc[1]]=='O':
+        return 2
+    elif board[loc[0]][loc[1]]=='#':
+        return 0
+    else: return 3
+# 성공하면 True, 실패하면 False, 그냥 괜찮으면 board
+def tilt(dir, board):
+    global N, M
+    dx, dy = [-1,0,1,0],[0,1,0,-1]
+    bLoc, rLoc= [], []
+    for i in range(N):
+        for j in range(M):
+            if board[i][j]=='B':
+                bLoc = [i,j]
+            elif board[i][j]=='R':
+                rLoc = [i,j]
+    B = [bLoc[0]+dx[dir],bLoc[1]+dy[dir]]
+    B_passed = False
+    while True:
+        temp=isOk(board, B)
+        if temp==0:
+            B[0]-=dx[dir]
+            B[1]-=dy[dir]
+            break
+        elif temp==2:
+            return False
+        elif temp==3:
+            B_passed = True
+        B[0]+=dx[dir]
+        B[1]+=dy[dir]
+    if B_passed:
+        B[0]-=dx[dir]
+        B[1]-=dy[dir]
+    R = [rLoc[0]+dx[dir],rLoc[1]+dy[dir]]
+    R_passed = False
+    while True:
+        temp = isOk(board, R)
+        if temp==0:
+            R[0]-=dx[dir]
+            R[1]-=dy[dir]
+            break
+        elif temp==2:
+            return True
+        elif temp ==3:
+            R_passed = True
+        R[0]+=dx[dir]
+        R[1]+=dy[dir]
+    if R_passed:
+        R[0]-=dx[dir]
+        R[1]-=dy[dir]
+    ret_board =copy.deepcopy(board)
+    ret_board[bLoc[0]][bLoc[1]]='.'
+    ret_board[rLoc[0]][rLoc[1]]='.'
+    ret_board[R[0]][R[1]]='R'
+    ret_board[B[0]][B[1]]='B'
+    return ret_board
+def board2str(board):
+    ret = ""
+    for b in board:
+        temp = "".join(b)
+        ret+=temp
+    return ret
+def bfs():
+    queue = deque()
+    queue.append([board, 0])
+    visited = dict()
+    visited[board2str(board)]=True
+    while queue:
+        temp_board, count = queue.popleft()
+        for i in range(4):
+            ret_temp = tilt(i, temp_board)
+            if ret_temp == True:
+                return count+1
+            elif ret_temp == False or count+1==11:
+                continue
+            vi=board2str(ret_temp)
+            if vi not in visited:
+                visited[vi]=True
+                queue.append([ret_temp,count+1])
+    return -1
+print(bfs())

--- a/김준서/Week_10/B2212.py
+++ b/김준서/Week_10/B2212.py
@@ -1,0 +1,10 @@
+N = int(input())
+K = int(input())
+sensor = sorted(list(set(map(int,input().split(" ")))))
+dist = sorted([sensor[i+1]-sensor[i] for i in range(len(sensor)-1)])
+if K-1>=len(dist):
+    print(0)
+    exit()
+for _ in range(K-1):
+    dist.pop()
+print(sum(dist))


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B13460 구슬탈출 2
일반적인 BFS문제라 풀이를 떠올리는 건 어렵지 않은데 시뮬레이션 구현이 까다롭다.
구현해야 할 시뮬레이션
1. 구슬 두개가 같은 줄에 위치할 때 떨궈진 순서를 고려해야 함
2. 동시에 구멍에 들어가면 실패, 빨간 구슬만 구멍에 들어가야 함

<img width="699" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/e69d3e2c-c2a1-4ace-ba57-3d952a426362">

1번을 구현하기 위해서 일단 각 구슬의 위치를 기억하게 하고, 무작정 떨군다. 
<img width="544" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/7de24c7b-b23a-4534-91a9-f810f1b4c445">
기울인 방향에 이미 구슬이 위치해있을 경우 나중에 떨어진 구슬의 위치를 재조정한다.

2번을 구현하기 위해서는 파란 구슬만 생각하면 된다. 파란 구슬이 들어가면 빨간 구슬이 들어갔건 말건 실패한 케이스 이므로 우선적으로 파란 구슬이 구멍에 들어갔는지 체크됐다면 바로 해당 케이스는 폐기한다. 빨간 구슬이 들어갔다면 해당 케이스는 성공, 값을 리턴한다.

##### B2212_센서
<img width="672" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/47feb53a-f8ec-459f-86c6-6b77895b0de0">

각 센서들 사이의 거리순으로 정렬하고 max값을 k-1만큼 없애준다.
그리디 문제라고는 하는데 이런문제까지 그리디라고 해야하는지는 잘 모르겠음;
양심고백) 처음에 dp로 접근했다가 망해서 해설보고 풀었습니다


##### B11048 이동하기
대표적인 dp. 
오른쪽, 아래, 대각선으로 이동 가능하며 취할 수 있는 사탕의 최대 갯수를 구하는 문제.
dp를 각 칸까지 도달하는데 얻을 수 있는 최대 사탕 갯수로 설정하면 dp[N][M]을 답으로 도출할 수 있다.
점화식은 dp[i][j] = max(dp[i-1][j], dp[i][j-1])
대각선을 고려하지 않은 이유는 어차피 오른쪽 아래, 아래 오른쪽 방향으로 오는 케이스가 항상 대각선으로 오는 경우보다 크거나 같기 때문


<hr>

### 🤯 이슈 & 질문
