### PR TITLE
[Week11] P72411_메뉴리뉴얼, B12865_평범한배낭, B1562_계단수

### DIFF
--- a/김준서/Week_11/B12865.py
+++ b/김준서/Week_11/B12865.py
@@ -1,0 +1,23 @@
+from collections import deque
+from heapq import heappop, heappush
+N, K = map(int, input().split(" "))
+obj = []
+for _ in range(N):
+    W, V = map(int, input().split(" "))
+    obj.append([W,V])
+def solution(N, K):
+    dp = [[0 for _ in range(N)] for _ in range(K+1)]
+    for weight in range(1, K+1):
+        for p in range(N):
+            W, V = obj[p]
+            if p==0:
+                if weight<W:
+                   continue
+                else:
+                    dp[weight][p]=V
+            elif weight<W:
+                dp[weight][p]=dp[weight][p-1]
+            else:
+                dp[weight][p]=max(dp[weight-W][p-1]+V, dp[weight][p-1])
+    return dp[K][N-1]
+print(solution(N, K))

--- a/김준서/Week_11/B1562.py
+++ b/김준서/Week_11/B1562.py
@@ -1,0 +1,32 @@
+from collections import defaultdict
+N = int(input())
+
+
+def solution(N):
+    def visited(origin, added):
+        return origin | (1 << added)
+
+    dp = [[defaultdict(int) for _ in range(N)] for _ in range(10)]
+    for i in range(1, 10):
+        dp[i][0] = {visited(0, i): 1}
+    for j in range(1,N):
+        for i in range(10):
+            if i-1 != -1:
+                for k, v in dp[i-1][j-1].items():
+                    new_visited = visited(k, i)
+                    dp[i][j][new_visited] += v
+            if i+1 != 10:
+                for k, v in dp[i+1][j-1].items():
+                    new_visited = visited(k, i)
+                    dp[i][j][new_visited] += v
+    answer = 0
+    for i in range(10):
+        for k, v in dp[i][N-1].items():
+            if k == 1023:
+                answer += v
+    return answer%1000000000
+
+
+print(solution(N))
+
+

--- a/김준서/Week_11/P72411.py
+++ b/김준서/Week_11/P72411.py
@@ -1,0 +1,31 @@
+from itertools import combinations
+import copy
+def combs(order, n):
+    temp = list(combinations(list(order),n))
+    answer = []
+    for tem in temp:
+        st = ''.join(tem)
+        answer.append(st)
+    return answer
+def solution(orders,course):
+    answer=[]
+    temp=[]
+    for order in orders:
+        temp.append(sorted(order))
+    orders=copy.deepcopy(temp)
+    for c in course:
+        dicts = {}
+        max = 0
+        for order in orders:
+            for comb in combs(order, c):
+                if comb in dicts:
+                    dicts[comb]+=1
+                else:
+                    dicts[comb]=1
+        dicts = sorted(dicts.items(),key=lambda x:x[1],reverse=True)
+        temp = []
+        for dict in dicts:
+            if dicts[0][1]==dict[1] and dict[1]!=1:
+                answer.append(dict[0])
+            else: break
+    return sorted(answer)


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

### P72411_메뉴리뉴얼1
메뉴 조합식을 찾으면 되는 문제입니다.
각 메뉴에서 원소가 n개인 조합을 구하는 함수를 따로 만들어서
각 메뉴별로 해당 함수를 적용한 후에 해당 조합의 갯수를 hashmap 구조로 수를 세도록 하였습니다

### B12865_평범한배낭
처음엔 branch and bound를 이용해서 문제를 해결하려 했습니다.
<img src="https://github.com/KB-team3/AlgoGGang/assets/99449600/fd7e03f4-965c-4a30-b3dd-0ce0bcad9c4c" width="400" height="200"/>

학교에서 배운 0/1 knapsack 문제 해결법이라 풀릴줄 알았는데 시간초과가 뜨네요;

bfs 방식으로 현재 아이템을 선택하거나 선택하지 않았을 때 얼마나 유망한지를 branch 값 탐색을 통해 예측한 후에 두가지 케이스 모두 priority queue에 넣어서 가장 유망한 큐를 우선 탐색하도록 하는 방식으로 구현하였습니다. 최대 무게가 크지 않아서 dp방식보다 느린 듯.

dp 방식 해결법은 생각이 안나서 답지 봤습니다;
각 아이템 번호별로 N번까지 사용한 케이스와 가능한 최대 무게로 나누어서 dp를 구현하였던데
솔직히 처음보는 문제였으면 죽었다 깨어나도 못풀었을듯;

### B1562_계단수
진짜 야무지게 풀었습니다.

계단 수가 만들어지기 위해서는 0부터 9까지 모두 한번 이상씩 추가되어야 하는데 인접한 수의 차이가 1이여야 하죠.
이를 2차원 보드 게임 형식으로 생각해봤습니다. 보드의 가로길이는 문자열의 갯수, 세로길이는 0부터 9까지입니다.

- 조건 1) 플레이어는 맨 왼쪽 열에 위치하고(1부터 9) 오른쪽 대각선(위아래)방향으로만 움직일 수 있으며, 
- 조건 2) 보드 오른쪽 끝열(0부터 9)까지 갔을 때 0부터 9까지 모두 방문해본 플레이어의 수를 새는거죠.

이렇게 생각하면 지난번 dp문제랑 비슷해집니다. 
일단 조건 1만 생각하고 문제를 보겠습니다.

<img src="https://github.com/KB-team3/AlgoGGang/assets/99449600/decedf87-a0d0-471e-b2ab-7becfa6f0ee9" width="600" height="400"/>

처음 보드 dp는 다음과 같습니다. 첫번째 수는 0이 될 수 없으니 1부터 9까지만 1로 초기화 해줍니다.
다음 열이 어떻게 변화하는지 보겠습니다.

<img width="600" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/1be9f8ed-3f36-4f33-bb86-8ff85b3908ab">

(0,1)까지 이동할 수 있는 경우의 수는 (1,0)에서 대각선 위로 이동하는 경우밖에 없으니 그대로 대입해줍니다.

<img width="600" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/3e1c61ed-8d88-4521-bec5-f90e0fd82dec">

(1,1)까지 이동할 수 있는 경우의 수는 (0,0)에서 대각선 아래, (2,0)에서 대각선 위이니 0+1=1 입니다.

<img width="600" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/e9799883-2c43-4d35-9b5c-95a118ab577c">

(2,1)은 (1,0), (3,0)에서 이동할 수 있으니 1+1=2 입니다.

<img width="600" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/7c5189ab-af24-4e32-a023-7210aff529a1">

이대로 쭉 똑같이 N열까지 대입을 해주고, N열에 있는 모든 값을 더하면 정답이 나옵니다.

근데 우리는 조건 2도 만족시켜야 하죠.

이걸 위해서 bfs, dfs에서 많이 사용했던 visited 개념을 사용하기로 했습니다.

저 보드칸에 단순히 1, 2와 같은 경우의 수만 넣는게 아니라, 지금까지 (0, 1, 2)를 방문해온 플레이어의 수, (1, 2, 3)을 방문해온 플레이어의 수
이런식으로 고도화해서 N열까지 갔을때 (0, 1, 2, 3, 4, 5, 6, 7, 8 9) 모두를 방문해온 플레이어의 수만 카운팅하면 정답을 알 수 있겠죠.

<img width="600" alt="image" src="https://github.com/KB-team3/AlgoGGang/assets/99449600/ae831a85-3f59-4afd-bbaf-43140cd1de8b">

근데 visited를 boolean배열로 선언해놓으면 hashmap구조를 이용할때도 번거롭고, 이문제 메모리 제한이 빡세서 메모리가 터질꺼에요.
우리가 체크해야 하는 visited 크기가 0-9이니 10가지만 체크하면 된다는 것에서 착안해서, 비트마스킹 기법을 이용하면 낮은 메모리와 빠른 속도로 방문 여부를 체크할 수 있게 됩니다.

비트마스킹 기법에 대한 설명은 
https://mygumi.tistory.com/361
에 잘 설명 되어 있습니다. 이거 설명은 조금 빡세서;


<hr>

### 🤯 이슈 & 질문
