### PR TITLE
[Week_14] P43164_여행경로, P43238_입국심사, P84512_모음사전

### DIFF
--- a/신선영/Week_14/P43164_여행경로.py
+++ b/신선영/Week_14/P43164_여행경로.py
@@ -1,0 +1,38 @@
+def solution(tickets):
+    # DFS: 재귀 (인덱스 사용?)
+    # 순서대로 탐색하면서 [0]이 [1]과 같다면 append
+
+    def travel(i, v, l):
+        global check
+        if check == 1:
+            return 
+        
+        if len(l) == len(tickets) and 0 not in v:
+            l.append(tickets[i][1])
+            answer.append(list(l))
+            check = 1
+            return
+
+        for j in range(len(tickets)):
+            if v[j] == 0 and tickets[j][0] == tickets[i][1]:
+                l.append(tickets[j][0])
+                v[j] = 1
+                travel(j, v, l)
+                v[j] = 0
+                l.pop(-1)
+
+
+    answer = []
+    global check
+    check = 0
+    tickets = sorted(tickets)	# 알파벳 순서 빠른대로 탐색해야됨
+    for idx, t in enumerate(tickets):
+        if check:
+            break
+        if t[0] == "ICN":	# 인천공항에서 출발하는 경우 모두 탐색
+            visited = [0] * len(tickets)
+            lst = ["ICN"]	# 시작점 저장
+            visited[idx] = 1
+            travel(idx, visited, lst)
+                
+    return answer[0]

--- a/신선영/Week_14/P43238_입국심사.java
+++ b/신선영/Week_14/P43238_입국심사.java
@@ -1,0 +1,28 @@
+import java.util.*;
+
+class Solution {
+    public long solution(int n, int[] times) {
+        Arrays.sort(times);
+        long answer = 0;
+        long left = 0;
+        long right = times[times.length - 1] * (long) n;
+        
+        while (left <= right) {
+            long mid = (left + right) / 2;
+            long cnt = 0;   // 심사 받을 수 있는 사람 수
+        
+            for (int t : times) {
+                cnt += mid / t;
+            }
+            
+            if (cnt >= n) {
+                answer = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        
+        }
+       return answer;
+    }
+}

--- a/신선영/Week_14/P84512_모음사전.py
+++ b/신선영/Week_14/P84512_모음사전.py
@@ -1,0 +1,22 @@
+def solution(word):
+    vowels = ['', 'A', 'E', 'I', 'O', 'U']
+    
+    # 1부터 55555까지 1, 2, 3, 4, 5만 포함한 숫자 순서대로 저장 후 정렬
+    idxs = [0] + sorted([str(x) for x in range(1, 55556) if check(str(x))])
+
+    idx_word = ''      # 입력된 문자열을 숫자로 변경
+    for w in word:
+        idx_word += str(vowels.index(w))
+
+    return idxs.index(idx_word)
+
+def check(check_num):
+    # 12345만 포함하고 있는지 체크하는 함수
+    return all(n in '12345' for n in check_num)
+
+# check 함수 이렇게 정의하면 시간은 더 빠름
+# def check(n):
+#     if '0' not in n and '6' not in n and '7' not in n and '8' not in n and '9' not in n:
+#         return True
+#     else:
+#         return False


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### P43164_여행경로 / DFS
끝까지 경로를 찾는 거라 DFS를 이용했다.
먼저 알파벳 순서가 앞서는 경로를 찾아야 하기 때문에 항공권을 정렬해주고
인천공항에서 출발하는 경로부터 찾아서 인덱스를 이용해 DFS
현재의 도착 지점에서 출발하는 경우가 있다면 정답 리스트에 넣고 재귀
정답 리스트의 길이가 전체 항공권의 수와 같고, 모두 방문했다면 답에 해당
정렬했기때문에 가장 먼저 나오는 결과가 정답이 됨
처음에는 모두 구했는데, 테스트케이스 1번이 400ms가 나와서 고민하다가
하나라도 완성된 경우 그만 찾게 했더니 0.07ms로 차이가 많이 났다
1번 테케가 전체 다 돌면 오래걸리게 되어있는듯

##### P43238_입국심사 / 이진탐색

이분 탐색으로 푸는 방법을 고민해봤는데 심사관이 아니라 시간의 최소 최대값을 정해 놓고 하는 거였다.
0부터 가장 긴 소요 시간의 범위 내에서 각 시간마다 몇 명까지 심사 가능한지 세보고(cnt 변수),
더 크면 일단 그 답으로 지정해 놓고 더 작은 값도 가능한지 확인해봄
처음에는 cnt == n으로 따로 체크해서 바로 return했는데 그러면 더 작은 값이 있을 수도 있으니까 이분탐색에는 적합하지 않았던 것 같음!

##### P84512_모음사전
개수가 많지 않아서 완전탐색답게 모두 다 구현해놓고 인덱스로 찾았다.
1, 11, 111, ..., 55555까지 모두 담은 리스트를 만들고,
제공된 단어를 'A' - 1, 'E' - 2 등의 숫자로 매치해서 변경한 후
만들어 놓은 리스트에서 인덱스를 찾으면 된다.
 
숫자 리스트를 만들 때는 1에서 55555까지 for문을 돌린 후 1, 2, 3, 4, 5만 포함되어 있는지 확인하는 함수를 따로 만들었다
이때 숫자 형태로 넣으면 1, 2, 3, 4, 5로 정렬이 되지만 문자열로 넣으면 1, 11, 111... 이렇게 정렬이 된다.
all 함수를 사용하는 법도 배웠는데, 시간 효율은 '0' not in ... 이런 식으로 하는 게 더 빠르다.
처음에 4번 테케에서 런타임에러가 났는데 for문을 55556까지 안 하고 55555까지 해서..
vowels 앞의 빈 ''과 숫자 배열 앞의 [0]은 모두 인덱스 1부터 사용하기 위해 넣었다

<hr>

### 🤯 이슈 & 질문

