### PR TITLE
[Week_14] P43164_여행경로, P43238_입국심사, P84512_모음사전

### DIFF
--- a/곽승규/Week_14/P43164_여행경로.py
+++ b/곽승규/Week_14/P43164_여행경로.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+
+def solution(tickets):
+    answer = []
+    # 인접리스트 생성
+    def init():
+        route = defaultdict(list)
+        for key, value in tickets:
+            route[key].append(value)
+        return route
+    
+    def dfs():
+        stack = ['ICN']
+        path = []
+        while len(stack) > 0: # 스택이 빌때까지
+            top = stack[-1]
+            # top 위치에서 출발하는 티켓이 없거나 티켓을 다 썼을 때
+            if top not in route or len(route[top]) == 0:
+                path.append(stack.pop())
+            else:
+                stack.append(route[top].pop(0))
+        return path[::-1] # 거꾸로 출력
+    
+    route = init()
+    for r in route:
+        route[r].sort()
+    answer = dfs()
+        
+    return answer

--- a/곽승규/Week_14/P43238_입국심사.py
+++ b/곽승규/Week_14/P43238_입국심사.py
@@ -1,0 +1,19 @@
+def solution(n, times):
+    answer = 0
+    start, end = 1, max(times) * n
+    answer = end
+    
+    while start <= end:
+        mid = (start + end) // 2
+        
+        people = 0
+        for time in times:
+            people += (mid // time)
+        
+        if people < n:
+            start = mid + 1
+        else:
+            end = mid - 1
+            answer = min(answer, mid)
+        
+    return answer


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

# 문제1 P43164_여행경로
- dfs로 풀어야겠다는 생각은 들었지만 구현부분에서 모르는 부분이 있어 참조함
- 우선 defaultdict 을 다시한번 공부하게 되었음! 파라미터로 어떤 걸 주느냐에 따라 처음 초기값의 타입을 정해준다는 걸 배우게 됨
- 그리고 dfs를 재귀뿐만 아니라 stack으로도 구현할 수 있다는 걸 알게 됨
- stack의 맨 위 (top)을 가지고 와서 현재 탑에 있는 위치에서 출발하는 티켓이 없거나 티켓을 다 썼을 때 path에 추가해주고 그 반대의 경우는 stack에 넣음으로써 dfs를 구현

# 문제2 P43238_입국심사
- 이분탐색이라는 힌트가 있어서 이분탐색을 이해했지.. 만약 그런 말이 없었으면 그냥 했을텐데...그럼 무조건 시간초과날듯..ㅋ
- 이분탐색은 우선 정렬된 리스트가 있고 start, end을 정해준 후 mid값을 구하면서 원하는 답을 찾는 알고리즘임
- start, end가 시간이 되어야 한다는 것 까지는 알 수 있었지만 mid를 무엇과 비교해야 하는지 몰라서 구글링..! 
- 그 결과, times의 각 time을 mid // time 하면 mid라는 시간동안 각 심사관이 심사할 수 있는 사람의 수가 나온다는 걸 알게 되었음
- 그래서 이를 다 더한 결과와 n을 비교해서 범위를 좁히는 이분탐색을 했음! 

# 문제3 P84512_모음사전
아직 안풀었음

<hr>

### 🤯 이슈 & 질문
