### PR TITLE
[Week_14] P43164_여행경로, P43238_입국심사, P84512_모음사전

### DIFF
--- a/윤상우/Week_14/P43164_여행경로.py
+++ b/윤상우/Week_14/P43164_여행경로.py
@@ -1,0 +1,32 @@
+from collections import defaultdict
+
+def solution(tickets):
+    answer = []
+    path = defaultdict(list)
+
+    # ticket 배열 -> {출발지 : [목적지1, 목적지2, 목적지3 ...]} 형태로 바꿔주기
+    for ticket in tickets:
+        path[ticket[0]].append(ticket[1])
+
+    # path의 목적지 배열을 역순으로 정렬
+    # 맨 뒤부터 stack에 들어가기 때문
+    for key in path.keys():
+        path[key].sort(reverse=True)
+
+    stack = ['ICN']
+    
+    # 스택에 원소가 없어질때까지 반복
+    while stack:
+        # 스택에 제일 마지막에 추가된 목적지
+        top = stack[-1]
+        
+        # 출발지를 top으로 잡은 여행경로가 path에 없는 경우 맨 위의 원소를 answer에 넣어준다.
+        if not path[top]:
+            answer.append(stack.pop())
+        else:
+        # 그렇지 않은 경우 스택에 넣음
+            stack.append(path[top].pop())
+
+    answer.reverse()
+
+    return answer

--- a/윤상우/Week_14/P43238_입국심사.py
+++ b/윤상우/Week_14/P43238_입국심사.py
@@ -1,0 +1,21 @@
+def solution(n, times):
+    answer = 0
+    left, right = 1, min(times) * n
+    
+    while left <= right: 
+
+        mid = (left + right) // 2
+        people = 0
+
+        for time in times:
+            people += mid // time
+            if people >= n:
+                break
+
+        if people >= n:
+            answer = mid
+            right = mid - 1
+        elif people < n:
+            left = mid + 1
+
+    return answer

--- a/윤상우/Week_14/P84512_모음사전.py
+++ b/윤상우/Week_14/P84512_모음사전.py
@@ -1,0 +1,11 @@
+from itertools import product
+
+def solution(word):
+    answer = []
+    for i in range(1,6):
+        
+        for p in product(['A','E','I','O','U'], repeat=i):
+            answer.append(''.join(list(p)))
+    
+    answer.sort()
+    return answer.index(word) + 1


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### P43164_여행경로

1. ticket 배열 -> {출발지 : [목적지1, 목적지2, 목적지3 ...]} 형태로 바꿔주기
2. path의 목적지 배열을 역순으로 정렬(맨 뒤부터 stack에 들어가기 때문)
3. 출발지는 무조건 ICN이니 ICN이 들어간 stack 초기 설정
4. 스택에 제일 마지막에 추가된 목적지 = top으로 설정
5. 출발지를 top으로 잡은 여행경로가 path에 없는 경우 맨 위의 원소를 answer에 넣어준다. 그렇지 않은 경우 스택에 넣음
6. 스택에 원소가 없어질때까지 반복

##### P43238_입국심사

이분탐색 문제라는 것을 아는것이 핵심

이분탐색의 범위, mid, 기준에 대해 말로 잘 정리해놓은 곳이 있어 가져와보았습니다.

범위 : 심사를 하는데 총 걸리는 시간. 1분 ~ 가장 비효율적으로 심사를 받았을 때 걸리는 시간(분)
mid : 모든 심사관들에게 주어진 시간. 따라서 people 은 모든 심사관들이 mid분 동안 심사한 사람의 수
기준 : 
1. mid 동안 심사한 사람의 수(people)가 심사 받아야할 사람의 수(n)보다 많거나 같을 경우에는 시간이 충분 -> 주어진 시간을 줄이고
2. 심사 받아야할 사람의 수(n)보다 적은 경우에는 시간이 부족 -> 주어진 시간을 늘린다. (left = mid + 1)

##### P84512_모음사전

모음이 다섯개밖에 없어서 길이가 1~5 까지 경우의수는 5의 5제곱 (3125) 밖에 되지 않는다.
그래서 모든 경우의 수를 배열에 추가해서 해당 word의 인덱스를 찾는 방향으로 갔다.

1. 길이에 대한 for문
2. A,E,I,O,U에 대한 중복순열로 해당 길이의 단어 만들기
3. 중요! 1,2 step을 진행하면 A,E,I,O,U,AA... 이런식으로 배열이 만들어지는데, 우리의 목적과 맞지 않다! 그래서 배열을 정렬해준다.
7. word의 인덱스 + 1을 return (인덱스는 0부터 시작이니까)

<hr>

### 🤯 이슈 & 질문
