### PR TITLE
[Week_15] P17683_방금 그 곡, P77484_로또의 최고순위와 최저순위, P43165_타겟넘버

### DIFF
--- a/신선영/Week_15/P17683_방금그곡.py
+++ b/신선영/Week_15/P17683_방금그곡.py
@@ -1,0 +1,32 @@
+def getNotes(lst, length):  # 텍스트로 주어진 음을 리스트로 바꿈 (# 포함)
+    notes = []
+    for i in range(length):
+            if lst[i] == "#":
+                notes.pop(-1)
+                notes.append(lst[i - 1:i + 1])
+            else:
+                notes.append(lst[i])
+    return notes
+
+def solution(m, musicinfos):
+    answer = ["(None)", 0] # 일치하는 값 없는 경우 (None) 출력
+    m = getNotes(m, len(m))
+    
+    for i in musicinfos:
+        info = i.split(",")
+        
+        # 음악 재생 가능한 시간 (초 단위로 계산)
+        sec = (int(info[1].split(":")[0]) - int(info[0].split(":")[0])) * 60 + int(info[1].split(":")[1]) - int(info[0].split(":")[1])
+        
+        notes = getNotes(info[3], len(info[3]))
+        
+        # 제시된 음악의 음을 초만큼 계산
+        fullnotes = notes * (sec // len(notes)) + notes[:sec % len(notes)]
+        for i in range(len(fullnotes) - len(m) + 1):
+            # 포함되는 경우 찾기
+            if fullnotes[i : i + len(m)] == m:
+                if sec > answer[1]:
+                    answer[0] = info[2]
+                    answer[1] = sec
+            
+    return answer[0]

--- a/신선영/Week_15/P43165_타겟넘버.java
+++ b/신선영/Week_15/P43165_타겟넘버.java
@@ -1,0 +1,23 @@
+class Solution {
+    public static int answer;
+    public static void DFS(int idx, int cur, int[] numbers, int target) {
+        // 마지막 인덱스에 도달한 경우 타겟 넘버가 되는지 확인
+        if (idx == numbers.length) {
+            if (cur == target) {
+                answer++;
+            }
+            return;
+        }
+        
+        // 더하는 경우와 빼는 경우 각각 탐색
+        DFS(idx + 1, cur - numbers[idx], numbers, target);
+        DFS(idx + 1, cur + numbers[idx], numbers, target); 
+    }
+    
+    public int solution(int[] numbers, int target) {
+        answer = 0;
+        DFS(0, 0, numbers, target);
+        
+        return answer;
+    }
+}

--- a/신선영/Week_15/P77484_로또의최고순위와최저순위.py
+++ b/신선영/Week_15/P77484_로또의최고순위와최저순위.py
@@ -1,0 +1,18 @@
+def solution(lottos, win_nums):
+    zero = 0    # 알아볼 수 없는 번호의 수
+    yes = 0     # 당첨된 번호의 수
+
+    for l in lottos:
+        if l == 0:
+            zero += 1
+        elif l in win_nums:
+            yes += 1
+    
+    a = 7 - (yes + zero)    # 알아볼 수 없는 것도 모두 일치한다고 가정
+    b = 7 - yes
+    if a >= 7:  # 한개도 안 맞는 경우 낙첨이니 6등으로 변환
+        a = 6
+    if b >= 7:
+        b = 6
+    
+    return [a, b]


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### P17683_방금 그 곡

먼저 음을 무조건 split하면 #이 고려되지 않기 때문에 따로 함수를 만들어서 #의 경우의 수도 세서 음계만 담은 배열을 만든다. 기억한 멜로디와 곡 정보 모두 같은 로직으로 일치시킨다.
그리고 시작 시간과 종료 시간을 이용해 음악이 재생된 시간을 초로 치환한다.
그 시간만큼 음악을 반복하고, 기억한 음악이 포함된 경우 재생 시간을 비교하여 가장 큰 값을 답으로 제출한다.
처음에 제출하니 테케를 반 정도 틀려서 확인했더니, len으로 인덱스를 이용해서 일치하는 문자열이 있는지 찾는 중 +1을 안 해서 원래 음악과 들은 음악의 길이가 같은 경우가 카운트되지 않았다. 간단한 오류인데 찾는 데 오래 걸렸음..
문제를 잘 이해하고 입력된 값을 #을 고려해서 잘 치환하면 되는 문제였다.

##### P77484_로또의 최고순위와 최저순위

알아볼 수 없는 수와 이미 당첨이 확정된 수의 개수를 세서, 그걸 이용해 알아볼 수 없는 수가 모두 맞은 경우의 수는 최고 순위, 모두 틀렸다고 가정한 경우는 최저 순위라고 상정하여 답을 찾는다.

##### P43165_타겟넘버

무조건 끝까지 가야 하기 때문에 DFS를 사용했다.
순서를 바꾸지 않기 때문에 앞에서부터 차례대로 더하고, 빼는 경우만 분기를 나누어서 끝까지 탐색해주면 된다.
재귀를 이용해 다음 인덱스로 나아가며 더하거나 빼주고,
마지막 인덱스에 도달한 경우 타겟 넘버와 같은지 판단하여 정답에 1을 더한다.

<hr>

### 🤯 이슈 & 질문
