### PR TITLE
[Week_17] B9465_스티커, P17677_뉴스클러스터링, P154540_무인도여행

### DIFF
--- a/길민지/Week_17/B9565_스티커.py
+++ b/길민지/Week_17/B9565_스티커.py
@@ -1,0 +1,22 @@
+def solution():
+  # 입력
+  n = int(input())
+  sticker = [list(map(int, input().split())) for _ in range(2)]
+
+  dp = [[0]*n for _ in range(3)]
+  dp[0][0] = sticker[0][0]
+  dp[1][0] = sticker[1][0]
+
+  for i in range(1, n):
+    # 위에꺼 선택
+    dp[0][i] = max(dp[1][i-1], dp[2][i-1]) + sticker[0][i]
+    # 아래꺼 선택
+    dp[1][i] = max(dp[0][i-1], dp[2][i-1]) + sticker[1][i]
+    # 둘 다 선택 X
+    dp[2][i] = max(dp[0][i-1], dp[1][i-1], dp[2][i-1])
+
+  print(max(dp[0][n-1], dp[1][n-1], dp[2][n-1]))
+T = int(input())
+
+for _ in range(T):
+  solution()

--- a/길민지/Week_17/P154540_무인도여행.py
+++ b/길민지/Week_17/P154540_무인도여행.py
@@ -1,0 +1,35 @@
+# 재귀 깊이 제한 변경
+import sys
+limit_number = 10000
+sys.setrecursionlimit(limit_number)
+
+dx = [1, -1, 0, 0]
+dy = [0, 0, 1, -1]
+
+def DFS(maps, x, y):
+    days = int(maps[x][y])
+    isChecked[x][y] = 1
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if(nx<0 or ny<0 or len(maps)<=nx or len(maps[0])<=ny): continue
+        if maps[nx][ny] == 'X' or isChecked[nx][ny] == 1: continue
+        days += DFS(maps, nx, ny)
+    return days
+
+def solution(maps):
+    answer = []
+    global isChecked
+    isChecked = [[0]*len(maps[0]) for _ in range(len(maps))]
+    
+    for i in range(len(maps)):
+        for j in range(len(maps[i])):
+            if maps[i][j] == 'X' or isChecked[i][j] == 1:
+                continue
+            days = DFS(maps, i, j)
+            answer.append(days)
+    
+    if len(answer)==0:
+        answer.append(-1)
+    answer.sort()
+    return answer

--- a/길민지/Week_17/P17677_뉴스클러스터링.py
+++ b/길민지/Week_17/P17677_뉴스클러스터링.py
@@ -1,0 +1,35 @@
+def solution(str1, str2):
+    list1 = []
+    list2 = []
+    
+    # 집합 구하기
+    for i in range(1, len(str1)):
+        string = str1[i-1]+str1[i]
+        if string.isalpha():
+            list1.append(string.upper())
+    for i in range(1, len(str2)):
+        string = str2[i-1]+str2[i]
+        if string.isalpha():
+            list2.append(string.upper())
+    
+    if len(list1)==0 and len(list2)==0: 
+        return 65536
+    
+    # 합집합 구하기 
+    temp = list1.copy()
+    union = list1.copy()
+
+    for i in list2:
+        if i not in temp:
+            union.append(i)
+        else:
+            temp.remove(i)
+    
+    # 교집합 구하기
+    intersection = []
+    for i in list2:
+        if i in list1:
+            list1.remove(i)
+            intersection.append(i)
+            
+    return int(len(intersection)/len(union)*65536)


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### B9465_스티커
2행 n열로 배치되어있으므로 한 열에 한 개의 스티커만 선택해야하며 이전 스티커가 선택되지 않은 경우에 선택할 수 있는 점에서 DP를 떠올렸습니다.
![KakaoTalk_Photo_2023-08-23-17-00-55](https://github.com/KB-team3/AlgoGGang/assets/78344310/57f3c0f6-66c6-4e37-948a-f8da2d143ffb)
위 그림처럼 한 열에서 행할 수 있는 경우의 수는
1. 위의 스티커 선택 2. 아래의 스티커 선택 3. 둘 다 선택하지 않음
이 있습니다.

1은 이전에 2, 3번일 경우에 선택할 수 있고 2은 이전에 1, 3번일 경우, 3은 이전에 무슨 선택을 했든 선택할 수 있습니다.

따라서 solution 함수는
1. n 입력 받기
2. dp 리스트 생성 후 0번 열의 값 넣기
3. 1부터 n까지 for문을 돌며 1번, 2번, 3번 케이스의 최댓값 삽입하기
4. 마지막 dp 값 중 최댓값 출력하기

##### P17677_뉴스클러스터링
문제의 내용대로 2글자씩 끊어서 다중집합을 만들고 교집합과 합집합을 구해 자카드 유사도를 구하면 됩니다. 기존의 집합은 set을 사용하면 됐지만 중복을 허용하는 다중집합의 형태는 어떤 식으로 처리하는지 몰라서 검색해보았고, 별다른 라이브러리 없이 for문을 돌며 구해주어야 했습니다.

1. 집합 구하기 : 1 ~ len(str)만큼 for문을 돌며 대문자로 변환해서 2글자씩 리스트에 삽입
2. 합집합 구하기 : list1 + (list2-list1 차집합)을 해줘야하므로 union에 list1을 미리 복사해넣고, list1을 복사한 temp에 들어있지 않은 i를 union에 넣어줍니다. 한번 체크한 요소는 temp에서도 삭제해서 중복된 요소를 구분할 수 있게 해줍니다.
3. 교집합 구하기 : list2를 돌면서 list1에도 있는 요소라면 교집합에 추가해줍니다. 중복된 값을 구분해야하므로 여기서도 동일하게 체크한 요소는 list1에서 삭제합니다.

##### P154540_무인도여행
연결된 땅끼리의 숫자합을 구해야하므로 DFS/BFS를 사용해야합니다.
maps를 전체 탐색하며 X거나 이미 방문한 섬이 아니라면 DFS를 시작합니다.
DFS를 돌며 해당 칸의 숫자를 days에 더해 반환하고, 해당 칸의 방문 체크를 해줍니다. 
몇 가지 테스트케이스가 런타임 에러가 나서 헤맸는데, 질문하기 게시판을 보니 파이썬 기본 재귀 제한 때문임을 알 수 있었습니다.
기존 파이썬의 경우 재귀의 제한이 1000개로 되어있는데, 해당 문제는 maps가 최대 100x100이라 10000번의 재귀까지 허용해야합니다.
따라서 
```
import sys
limit_number = 10000
sys.setrecursionlimit(limit_number)
```
라는 코드를 추가해야했습니다.

<hr>

### 🤯 이슈 & 질문
