### PR TITLE
[Week_17] B9465_스티커, P17677_뉴스클러스터링, P154540_무인도여행

### DIFF
--- a/윤상우/Week_17/B9465_스티커
+++ b/윤상우/Week_17/B9465_스티커
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+def solution(stickers, n):
+    dp = stickers
+
+    if n >=2 :
+        dp[0][1] += dp[1][0]
+        dp[1][1] += dp[0][0]
+
+        for i in range(2,n):
+            dp[0][i] += max(dp[1][i-1], dp[1][i-2])
+            dp[1][i] += max(dp[0][i-1], dp[0][i-2])
+
+        print(max(dp[0][n-1], dp[1][n-1]))
+    
+t = int(input())
+
+for _ in range(t):
+    n = int(input())
+    stickers = [list(map(int, input().split())) for _ in range(2)]
+    solution(stickers, n)

--- a/윤상우/Week_17/B9465_스티커
+++ b/윤상우/Week_17/B9465_스티커
@@ -12,7 +12,7 @@ def solution(stickers, n):
             dp[0][i] += max(dp[1][i-1], dp[1][i-2])
             dp[1][i] += max(dp[0][i-1], dp[0][i-2])
 
-        print(max(dp[0][n-1], dp[1][n-1]))
+    print(max(dp[0][n-1], dp[1][n-1]))
     
 t = int(input())
 

--- a/윤상우/Week_17/P154540_무인도여행
+++ b/윤상우/Week_17/P154540_무인도여행
@@ -1,0 +1,54 @@
+from collections import deque
+                
+def solution(maps):
+    answer = []
+    
+    dx = [-1,1,0,0]
+    dy = [0,0,-1,1]
+    
+    len_x = len(maps)
+    len_y = len(maps[0])
+    
+    visited=[[False] *len_y for _ in range(len_x)]
+            
+    def isValid(x,y):
+        if x<0 or x>=len_x or y<0 or y>=len_y:
+            return False
+        return True
+
+    def bfs(start):
+        que = deque()
+        sum = int(maps[start[0]][start[1]])
+        que.append(start)
+        visited[start[0]][start[1]] = True
+        while que :
+            x,y = que.popleft()
+            for i in range(4):
+                next_x = x + dx[i]
+                next_y = y + dy[i]
+                
+                if not isValid(next_x, next_y) :
+                    continue
+                if visited[next_x][next_y] :
+                    continue
+                if maps[next_x][next_y] == 'X':
+                    continue
+                
+                sum += int(maps[next_x][next_y])
+                visited[next_x][next_y] = True
+                que.append([next_x,next_y])
+
+        return sum
+    
+    for i in range(len_x) :
+        for j in range(len_y) :
+            if maps[i][j] == 'X' or visited[i][j]: 
+                continue
+            print('[',i,j,']')
+            answer.append(bfs([i,j]))
+    
+    if not answer:
+        return [-1]
+    else:
+        return sorted(answer)
+    

--- a/윤상우/Week_17/P17677_뉴스클러스터링
+++ b/윤상우/Week_17/P17677_뉴스클러스터링
@@ -1,0 +1,39 @@
+from collections import Counter
+
+def solution(str1, str2):
+    str1 = str1.upper()
+    str2 = str2.upper()
+    list1 = []
+    list2 = []
+    for i in range(len(str1)-1):
+        if str1[i:i+2].isalpha() :
+            list1.append(str1[i:i+2])
+    for i in range(len(str2)-1):
+        if str2[i:i+2].isalpha() :
+            list2.append(str2[i:i+2])
+    
+    # inter = list((Counter(list1) & Counter(list2)).elements())
+    # union = list((Counter(list1) | Counter(list2)).elements())
+    
+    temp = list1.copy()
+    union = list1.copy()
+    
+    for i in list2:
+        if i not in temp:
+            union.append(i)
+        else:
+            temp.remove(i)
+            
+    inter = []
+    
+    for i in list2:
+        if i in list1:
+            list1.remove(i)
+            inter.append(i)
+    
+    if len(union)==0:
+        return 65536
+    else:
+        return int(65536 * len(inter)/len(union))
+     
+    return answer


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

### B9465_스티커

각 자리에서의 최대값을 갱신해가는 dp로 해결하였다.

최대값이 갱신되는 케이스는 두가지로, 둘 중 더 큰 값을 채택하는 방식!

![KakaoTalk_Image_2023-08-30-20-43-37](https://github.com/KB-team3/AlgoGGang/assets/64531982/0ec2a224-ff6a-4cbd-bd24-a65b94c141a5)

Case1) 지그재그

상하좌우의 스티커는 쓸 수 없으므로 대각선에 있는 dp값을 더해주면 된다.

Case2) 한칸 건너뛰기

만약 dp[0][0] + dp[1][1] + dp[0][2] 보다 dp[1][0] + dp[0][2]가 더 큰 경우가 있을 수 있다! 그러므로 dp[0][2]의 두 칸 전의 값을 더하는 경우도 고려를 해주어야 한다.

Case3) 안되는 케이스

이 케이스는 최대값이 될 수 없다. 왜냐하면 dp[0][0]을 선택하면, dp[1][2] 값도 더할 수 있기 때문이다.


### P17677_뉴스클러스터링

여러가지 조건으로 문자열을 다루는 문제다.

조건 1. 대소문자를 가리지 않는다 -> upper()로 해결
조건 2. 두개씩 자르되, 문자가 아닌 조각은 무시한다. -> isalpha()로 해결
조건 3. 중복집합의 교집합과 합집합을 구하기

이 조건은 2가지 케이스로 풀었다.

1) Counter를 이용하기

list 요소의 개수를 구해주는 라이브러리인 Counter은 교집합과 합집합을 구하는데 특화되어있다. 
따라서 교, 합집합의 요소들을 리스트로 바꾸어 이들의 길이만 추출해내면 자카드 유사도를 구할 수 있다.

2) list1과 list2를 비교해가며 각각 만들기

합집합의 경우, 임시리스트 하나를 복사하여 요소가 list2에 포함되지 않으면 'list2에 추가' + 'temp에서 삭제'를 해주며 갱신한다.

교집합의 경우, list1의 요소가 list2에 포함되면 'list1에서 삭제' + 'inter에 추가'를 해주며 갱신한다.

### P154540_무인도 여행

일반적인 BFS 문제에서

'X'인 공간은 방문하지 않는다는 조건, 'X'인 공간은 시작점으로 선정하지 않는 조건

이 두가지 조건만 추가하면 된다.


<hr>

### 🤯 이슈 & 질문
