### PR TITLE
[Week21] P12987_숫자게임, P87846_피로도, B1753_최단경로

### DIFF
--- a/곽승규/Week_21/B1753_최단경로.py
+++ b/곽승규/Week_21/B1753_최단경로.py
@@ -1,0 +1,39 @@
+# 최단경로
+# 다익스트라 활용하기
+
+import sys
+from queue import PriorityQueue
+input = sys.stdin.readline
+
+V, E = map(int, input().split()) # 정점개수, 간선개수
+K = int(input()) # 시작 정점 번호
+distance = [sys.maxsize] * (V+1) # 거리저장리스트, 충분히 큰 수로 초기화
+visited = [False] * (V+1) # 방문리스트
+myList = [[] for _ in range(V+1)] # 인접리스트
+q = PriorityQueue()
+
+for _ in range(E):
+  u, v, w = map(int, input().split())
+  myList[u].append((v,w))
+
+q.put((0,K)) # 0: 가중치, K: 시작점
+distance[K] = 0 # 시작점의 거리는 0임
+
+while q.qsize() > 0:
+  current = q.get()
+  current_value = current[1]
+  if visited[current_value]:
+    continue
+  visited[current_value] = True
+  for tmp in myList[current_value]:
+    next = tmp[0] # 다음 노드
+    value = tmp[1] # 가중치
+    if distance[next] > distance[current_value] + value: # 최소 거리로 업데이트
+      distance[next] = distance[current_value] + value
+      q.put((distance[next], next))
+
+for i in range(1, V+1):
+  if visited[i]:
+    print(distance[i])
+  else:
+    print('INF')

--- a/곽승규/Week_21/P12987_숫자게임.py
+++ b/곽승규/Week_21/P12987_숫자게임.py
@@ -1,0 +1,14 @@
+def solution(A, B):
+    answer = 0
+    
+    A.sort(reverse = True)
+    B.sort(reverse = True)
+    
+    for a in A:
+        if a >= B[0]:
+            continue
+        else:
+            answer += 1
+            del B[0]
+    
+    return answer

--- a/곽승규/Week_21/P87946_피로도.py
+++ b/곽승규/Week_21/P87946_피로도.py
@@ -1,0 +1,36 @@
+# 1. permutaion 8! -> posible
+# from itertools import permutations
+# def solution(k, dungeons):
+#     answer = -1
+    
+#     for p in permutations(dungeons, len(dungeons)):
+#         tmp = k
+#         count = 0
+        
+#         for need, spend in p:
+#             if tmp >= need:
+#                 tmp -= spend
+#                 count += 1
+#             else:
+#                 break
+#         answer = max(answer, count)    
+#     return answer
+
+# 2. dfs (backtracking)
+answer = 0
+def dfs(k, count, dungeons, visited):
+    global answer
+    if count > answer:
+        answer = count
+    for i in range(len(dungeons)):
+        if not visited[i] and k >= dungeons[i][0]:
+            visited[i] = True
+            dfs(k - dungeons[i][1], count+1, dungeons, visited)
+            visited[i] = False
+    
+def solution(k, dungeons):
+    global answer
+    
+    visited = [False] * len(dungeons)
+    dfs(k,0, dungeons, visited)
+    return answer


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### 문제1 숫자게임
- 정렬을 사용하면 쉽게 풀림
- 내림차순으로 정렬해도 되고, 오름차순으로 정렬해도 됨
- A의 순서가 정해져 있다고는 하지만 B의 값과 매칭만 해주는 것이라  A의 순서를 섞어도 상관없음
- 그다음 비교해주면서 정답 체크해주고 B의 원소 하나씩 지워가며 비교 대상 줄임

##### 문제2 피로도
우선 나는 이 문제를 2개로 풀어봤음
- 첫번째는 permutations으로 풀었는데 코드가 돌아가서 통과는 했음. 
- 그런데 만약 해당 문제처럼 범위가 괜찮으면 상관없는데 범위가 크면 모든 경우의 수를 따지면 시간초과가 날 수 있기 때문에 다른 방법인 DFS로도 풀어봄
- dfs를 통해 해당 던전을 갈 수 있으면 전체 피로도 K에서 현재 필요한 피로도를 빼주고, count를 올려가면서 dfs 재귀로 탐색 함!

##### 문제3 최단경로
전형적인 다익스트라 문제
우선 다익스트라를 하기 위해 우선순위 큐를 사용했는데 알고보니 heapq를 사용해서도 풀 수 있다고 해서 이를 알아볼려고 함.
- 인접리스트를 만들어 주고 , 처음 시작점에 해당하는 부분을 우선순위 큐에 넣은 후, 해당 거리는 0으로 바꿔주었다.
- 그리고 우선순위 큐가 빌 때까지 탐색하면서 처음 노드에서 다른 노드까지 갈 수 있는 최단거리를 업데이트 해주었다.
- 마지막에는 해당 노드를 방문 했다면 그 노드까지의 거리를 출력하고 아니면 INF 출력해주면서 끝

<hr>

### 🤯 이슈 & 질문
