### PR TITLE
[Week21] P12987_숫자게임, P87846_피로도, B1753_최단경로

### DIFF
--- a/신선영/Week_21/B1753_최단경로.py
+++ b/신선영/Week_21/B1753_최단경로.py
@@ -1,0 +1,43 @@
+import sys
+input = sys.stdin.readline
+
+
+V, E = map(int, input().split())  # V: 정점의 개수, E: 간선의 개수
+K = int(input())  # 시작 정점의 번호
+
+graph = [[] for _ in range(V + 1)]  # 정점: 1부터 시작
+
+visited = [0] * (V + 1)
+distance = [1e9] * (V + 1)
+
+for _ in range(E):
+    u, v, w = map(int, input().split())
+    graph[u].append([v, w])
+
+distance[K] = 0
+visited[K] = 1
+
+for g in graph[K]:
+    distance[g[0]] = g[1]
+
+for i in range(V - 1):
+    min_v = 1e9
+    idx = 0
+    for j in range(1, V + 1):
+        if distance[j] < min_v and not visited[j]:
+            min_v = distance[j]
+            idx = j
+
+    visited[idx] = 1
+
+    for j in graph[idx]:
+        if distance[idx] + j[1] < distance[j[0]]:
+            distance[j[0]] = distance[idx] + j[1]
+
+
+for i in range(1, V + 1):
+    d = distance[i]
+    if d == 1e9:
+        print("INF")
+    else:
+        print(d)

--- a/신선영/Week_21/P12987_숫자게임.py
+++ b/신선영/Week_21/P12987_숫자게임.py
@@ -1,0 +1,16 @@
+def solution(A, B):
+    answer = 0
+    L, i, j = len(A), 0, 0
+    A.sort()
+    B.sort()
+    
+    while j < L:
+        # 이길 수 있는 경우
+        if A[i] < B[j]:
+            answer += 1
+            i += 1
+            j += 1
+        else:
+            j += 1
+        
+    return answer

--- a/신선영/Week_21/P87946_피로도.py
+++ b/신선영/Week_21/P87946_피로도.py
@@ -1,0 +1,25 @@
+from itertools import permutations
+
+def solution(k, dungeons):
+    def exp(order, k):
+        cur = k
+        cnt = 0
+
+        for o in order:
+            n, c = dungeons[o][0], dungeons[o][1]
+            if cur >= n:    # 탐험이 가능한 경우
+                cur -= c
+                cnt += 1
+            else: return cnt
+            
+        return cnt
+    
+    answer = -1
+    orders = [x for x in range(len(dungeons))]
+    # 가능한 모든 탐험 순서 경우의 수
+    cases = list(permutations(orders, len(dungeons)))
+    
+    for c in cases:
+        answer = max(answer, exp(c, k))
+        
+    return answer


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### P12987_숫자게임

A의 순서가 이미 정해져 있는 건 의미가 없다. 둘 사이의 최선의 관계만 구하면 된다.
A와 B를 각각 정렬하고, 기준을 정해서 각각의 인덱스를 높여 가며 B가 최대한 많이 이길 수 있는 만큼 움직인다.
이길 수 없으면 이길 수 있을 때까지 인덱스를 높여 주고 끝에 도달 하면 종료

##### P87846_피로도

수가 8개까지로 제한되어 있어 완전탐색으로 풀어도 시간초과가 나지 않을 거라고 생각했습니다 (순서 경우의 수 최대 8!)
permutations를 이용해서 가능한 순서의 경우를 모두 구하고, 각 결과에서 방문할 수 있는 던전의 수를 찾은 뒤
최대값보다 크면 답을 갱신해주는 식으로 풀었음

##### B1753_최단경로 

다익스트라 문제..
배열만 이용해서 풀었더니 시간초과가 나서 heapq를 이용하는 방법으로 다시 시도해보겠습니다

<hr>

### 🤯 이슈 & 질문
