### PR TITLE
[Week22] P49189_가장 먼 노드, P43162_네트워크, B14503_로봇청소기

### DIFF
--- a/윤상우/Week_22/B14503_로봇청소기
+++ b/윤상우/Week_22/B14503_로봇청소기
@@ -11,30 +11,30 @@ dy=(0,1,0,-1)
 answer = 1
 map[r][c]=2
 
-que=deque([(r,c,d)])
-while(que):
-    now_r, now_c, now_d=que.popleft()
+while(1):
     flag=True
-    for i in range(now_d-1,now_d-5,-1):
-        if i<0 : i+=4
-        next_r=now_r+dx[i]
-        next_c=now_c+dy[i]
+    for _ in range(4):
+        d = (d+3) % 4
+        next_r=r+dx[d]
+        next_c=c+dy[d]
         if(next_r<0 or next_r>=N or next_c<0 or next_c>=M) : continue
         if(map[next_r][next_c]==0):
             map[next_r][next_c]=2
             answer+=1
-            que.append([next_r, next_c, i])
+            r=next_r
+            c=next_c
             flag=False
             break
     
     if(flag):
-        back_d = now_d+2
+        back_d = d+2
         if back_d>=4: back_d-=4
 
-        back_r=now_r+dx[back_d]
-        back_c=now_c+dy[back_d]
+        back_r=r+dx[back_d]
+        back_c=c+dy[back_d]
 
         if(map[back_r][back_c]==1): break
-        que.append([back_r, back_c, now_d])
+        r=back_r
+        c=back_c
 
 print(answer)

--- a/윤상우/Week_22/B14503_로봇청소기
+++ b/윤상우/Week_22/B14503_로봇청소기
@@ -1,0 +1,40 @@
+import sys
+from collections import deque
+input=sys.stdin.readline
+
+N,M=map(int, input().split())
+r,c,d=map(int, input().split())
+map=[list(map(int, input().split())) for _ in range(N)]
+
+dx=(-1,0,1,0)
+dy=(0,1,0,-1)
+answer = 1
+map[r][c]=2
+
+que=deque([(r,c,d)])
+while(que):
+    now_r, now_c, now_d=que.popleft()
+    flag=True
+    for i in range(now_d-1,now_d-5,-1):
+        if i<0 : i+=4
+        next_r=now_r+dx[i]
+        next_c=now_c+dy[i]
+        if(next_r<0 or next_r>=N or next_c<0 or next_c>=M) : continue
+        if(map[next_r][next_c]==0):
+            map[next_r][next_c]=2
+            answer+=1
+            que.append([next_r, next_c, i])
+            flag=False
+            break
+    
+    if(flag):
+        back_d = now_d+2
+        if back_d>=4: back_d-=4
+
+        back_r=now_r+dx[back_d]
+        back_c=now_c+dy[back_d]
+
+        if(map[back_r][back_c]==1): break
+        que.append([back_r, back_c, now_d])
+
+print(answer)

--- a/윤상우/Week_22/P43162_네트워크
+++ b/윤상우/Week_22/P43162_네트워크
@@ -1,0 +1,58 @@
+import java.util.*;
+class Solution {
+    static int [] parent;
+    static int len;
+    
+    public void union(int n1, int n2){
+        n1 = find(n1);
+        n2 = find(n2);
+        
+        if(n1 != n2){
+            if(n1 < n2){
+                for(int i=0; i<len; i++){
+                    if(parent[i]==n2){
+                        parent[i]=n1;
+                    }
+                }
+            }
+            else{
+                for(int i=0; i<len; i++){
+                    if(parent[i]==n1){
+                        parent[i]=n2;
+                    }
+                }
+            }
+        }
+    }
+    
+    public int find(int n){
+        if(parent[n]==n) return n;
+        return parent[n] = find(parent[n]);
+    }
+    
+    public int solution(int n, int[][] computers) {
+        int answer = 0;
+        parent = new int [n];
+        len = computers.length;
+        
+        for(int i=0; i<len; i++){
+            parent[i] = i;
+        }
+        
+        for(int i=0; i<len; i++){
+            for(int j=0; j<len; j++){
+                if(i==j) continue;
+                if(computers[i][j]==1){
+                    union(i,j);
+                }    
+            }
+        }
+        
+        HashSet<Integer> set = new HashSet<>();
+        for(int p : parent) set.add(p);
+        
+        answer = set.size();
+        
+        return answer;
+    }
+}

--- a/윤상우/Week_22/P49189_가장 먼 노드
+++ b/윤상우/Week_22/P49189_가장 먼 노드
@@ -1,0 +1,63 @@
+import java.util.*;
+class Solution {
+    
+    public static void djaikstra(){
+        int start = 1;
+        distance[1] = 0;
+        Queue<int []> que = new PriorityQueue<>(Comparator.comparingInt(arr -> arr[0]));
+        
+        que.add(new int[]{0, 1});
+        
+        while(!que.isEmpty()){
+            int [] now = que.poll();
+            int now_dist = now[0];
+            int now_node = now[1];
+            
+            if(now_dist > distance[now_node]) continue;
+            
+            for(int next_node : graph[now_node]){
+                int cost = now_dist + 1;
+                if(cost < distance[next_node]) {
+                    distance[next_node] = cost;
+                    que.add(new int[]{cost, next_node});
+                }
+            }
+            
+        }
+    }
+    
+    public static List<Integer>[] graph;
+    public static int [] distance;
+    
+    public int solution(int n, int[][] edge) {
+        int answer = 0;
+        int max_v = 0;
+        int max = Integer.MAX_VALUE;
+        graph = new List [n+1];
+        distance = new int [n+1];
+        
+        
+        for(int i=0; i<n+1; i++){
+            graph[i] = new ArrayList<>();
+            distance[i] = max;
+        }
+        
+        for(int [] e : edge){
+            graph[e[0]].add(e[1]);
+            graph[e[1]].add(e[0]);
+        }
+        
+        djaikstra();        
+        
+        for(int d : distance){
+            if(d == max) continue;
+            if(max_v < d) max_v = d;
+        }
+        
+        for(int d : distance){
+            if(d == max_v) answer++;
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

### P49189_가장 먼 노드

이 문제는 예전에 bfs로 푼 경험이 있어서 거리가 모두 1인 다익스트라로 한 번 풀어봤다.

1. 시작노드는 1, [거리, 노드] 배열을 자료형으로 갖는 우선순위큐를 생성한다. (우선순위는 거리로 오름차순)
2. 연결된 노드들을 방문하며 최단거리를 갱신하는 다익스트라 실행
3. distance배열에서 최대값을 구한다.
4. distance배열에서 최대값과 같은 원소가 있으면 answer를 증가시킨다.

단방향 그래프 뿐만아니라 양방향 그래프에서도 다익스트라 알고리즘이 적용되는 점을 깨달았다!

### P43162_네트워크

이 문제는 컴퓨터들이 연결되어있는지를 확인하는 문제였다. 따라서 유니온 파인드 알고리즘을 적용하였다.

1. 각자의 부모노드를 구하는 find 함수 정의
2. 노드들의 부모노드를 비교하여 상위 노드에 연결하는 union 함수 정의
1. computers 배열을 통해 연결되어 있으면 union을 실행해 부모 노드를 상위 노드로 통일해준다.
3. set에 부모노드들을 저장한 parent 배열을 넣는다. (중복 삭제)
4. set의 size가 정답이 된다.
5. 예를 들어 부모노드 배열 = [0,0,2] 이면 0번 노드와 1번노드는 연결되어있고, 2번 노드는 연결 되어있지 않다. 따라서 set = (0,2)이므로 네트워크는 2개가 된다.


### B14503_로봇청소기

이 문제는 bfs처럼 보이지만 코드를 짜다보니 굳이 bfs를 할 필요가 없는 4방 탐색 문제였다. 다만 조건이 좀 까다로운 문제...

1. 현재 위치에서 시계 반대방향(북서남동) 순서로 4방 탐색을 한다.
먼저, 청소기의 시작 방향이 0:북, 1:동, 2:남, 3:서 라고 문제에서 제시해줬기 때문에 방향벡터를 이에 맞게 설정했다. 근데 갑자기 시계반대방향으로 탐색하라길래 살짝 애를 먹었다. (d+3) % 4를 해주면 시계 반대방향으로 90도 꺾는 방향을 구할 수 있다!!
2. 청소가 안된 칸을 발견할 시 answer에 1을 추가해주고, 그 위치로 청소기를 이동시킨다.
3. 4방향 모두 청소가 되있거나 벽일 경우 후진한다. 단, 후진한 칸이 벽일 경우 청소기 작동을 종료하고, 벽이 아닌경우 다시 4방탐색을 진행한다.

이런 긴 호흡의 문제를 풀 때 항상 변수를 잘못 설정하거나, 미리 설정해놓은 값들을 바꿔버려 버리는 시간이 많아진다. 이 시간을 줄일 수 있도록 잘 메모하는 습관을 지녀야겠다.

<hr>

### 🤯 이슈 & 질문
