### PR TITLE
[Week22] P49189_가장 먼 노드, P43162_네트워크, B14503_로봇청소기

### DIFF
--- a/길민지/Week_22/B14503_로봇청소기.py
+++ b/길민지/Week_22/B14503_로봇청소기.py
@@ -1,0 +1,45 @@
+# 입력
+N, M = map(int, input().split())
+r, c, d = map(int, input().split())
+arr = [list(map(int, input().split())) for _ in range(N)]
+
+clean = [[0 for _ in range(M)] for _ in range(N)]
+dr = [-1, 0, 1, 0]
+dc = [0, 1, 0, -1]
+answer = 0
+
+while True:
+  # 1. 현재 칸이 청소되지 않은 경우, 청소
+  if clean[r][c] == 0:
+    clean[r][c] = 1
+    answer += 1
+  
+  # 2. 현재 칸의 주변 4칸 중 청소되지 않은 빈 칸이 없는 경우
+  check = False
+  for i in range(4):
+    nr = r + dr[i]
+    nc = c + dc[i]
+    if arr[nr][nc] == 1 or clean[nr][nc] == 1:
+      continue
+    check = True
+    break
+  # 한 칸 후진
+  if check is False:
+    r += dr[(d+6)%4]
+    c += dc[(d+6)%4]
+    if arr[r][c] == 1:
+      break
+    else:
+      continue
+      
+  # 3. 현재 칸의 주변 4칸 중 청소되지 않은 빈 칸이 있는 경우
+  while True:
+    d = (d+3)%4 # 반시계 90도 회전
+    nr = r+dr[d]
+    nc = c+dc[d]
+    if arr[nr][nc] == 0 and clean[nr][nc] == 0:
+      r = nr
+      c = nc
+      break
+      
+print(answer)

--- a/길민지/Week_22/P43162_네트워크.py
+++ b/길민지/Week_22/P43162_네트워크.py
@@ -1,0 +1,16 @@
+def dfs(start, check, n, computers):
+    check[start] = 1
+    for nn in range(n):
+        if computers[start][nn] == 1 and check[nn] == 0:
+            dfs(nn, check, n, computers)
+
+def solution(n, computers):
+    answer = 0
+    check = [0 for _ in range(n)]
+    
+    for i in range(n):
+        if check[i] == 1: 
+            continue
+        answer += 1
+        dfs(i, check, n, computers)
+    return answer

--- a/길민지/Week_22/P49189_가장먼노드.py
+++ b/길민지/Week_22/P49189_가장먼노드.py
@@ -1,0 +1,26 @@
+def solution(n, edge):
+    INF = float('inf')
+    graph = [[] for _ in range(n+1)]
+    cost = [INF] * (n+1)
+    que = []
+    
+    # 인접 버텍스 정보 저장
+    for v1, v2 in edge:
+        graph[v1].append(v2)
+        graph[v2].append(v1)
+    
+    que.append(1)
+    cost[1] = 0
+    
+    while que:
+        now = que.pop(0)
+        for i in graph[now]:
+            # 비용 갱신
+            if cost[i] == INF:
+                cost[i] = cost[now]+1
+                que.append(i)
+    
+    # INF 제외한 최대값 개수 세기
+    cost.remove(INF)
+    max_cost = max(cost)   
+    return cost.count(max_cost)


### PR DESCRIPTION
### 🚀 풀이 방법 / 알고리즘 분류

##### P49189_가장 먼 노드
그래프 문제라 저번처럼 다익스트라 알고리즘을 먼저 생각했는데, 간선에 비용이 없다보니 그냥 BFS를 이용해서 풀면 됐다.

1. edge 리스트를 인접 버텍스를 저장하는 graph 리스트로 변환한다.
2. 1번 노드의 비용(거리)을 0으로 설정하고 큐에 넣는다.
3. BFS를 돌리면서 비용이 INF인 인접 버텍스(아직 방문하지 않은 버텍스)의 비용을 갱신해주고 큐에 넣는다.
4. cost 리스트에서 INF를 제외하고 가장 큰 비용(가장 먼 거리)을 가진 버텍스의 개수를 반환한다.

##### P43162_네트워크
연결되지 않은 그래프가 몇개인지 세는 문제였다.

1. for문을 돌며 방문하지 않은 컴퓨터가 있는 경우 answer를 1 증가시키고 그 컴퓨터를 시작으로 dfs를 돌린다.
2. dfs로 해당 컴퓨터랑 연결된 컴퓨터들을 전부 방문처리한다.
3. answer를 반환한다.

##### B14503_로봇청소기
그냥 지시사항 그대로 코드를 짰다.

1. 입력을 받는다.
4. 현재 칸의 clean 리스트가 0일 경우 청소를 하고 answer를 1 증가시킨다.
5. 4방 탐색으로 청소되지 않은 빈 칸이 없는 경우 check 값을 True로 변경한다 -> 후진이 가능하다면 후진하고, 아니라면 종료한다.
6. 청소되지 않은 빈 칸이 있는 경우 이동할 수 있을 때까지 반시계 90도 회전을 하고 전진한다.
<hr>

### 🤯 이슈 & 질문
